### PR TITLE
clang-format and clang-tidy integration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+BasedOnStyle: Chromium
+IndentWidth: 4

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,23 @@ Checks: "*,
         -readability-else-after-return,
         -readability-identifier-length,
         -readability-static-accessed-through-instance,
+        -cppcoreguidelines-avoid-magic-numbers,
+        -readability-avoid-const-params-in-decls,
+        -altera-struct-pack-align,
+        -readability-magic-numbers,
+        -hicpp-signed-bitwise,
+        -readability-math-missing-parentheses,
+        -readability-avoid-nested-conditional-operator,
+        -android-cloexec-fopen,
+        -cppcoreguidelines-avoid-non-const-global-variables,
+        -readability-function-cognitive-complexity
+        -concurrency-mt-unsafe,
+        -misc-include-cleaner,
+        -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
+        -clang-analyzer-security.insecureAPI.strcpy,
+        -cppcoreguidelines-macro-to-enum,modernize-macro-to-enum,
+        -modernize-macro-to-enum,
+        -readability-function-cognitive-complexity
 "
 WarningsAsErrors: ''
 HeaderFilterRegex: ''

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,16 @@
+---
+Checks: "*,
+        -abseil-*,
+        -fuchsia-*,
+        -llvmlibc-*,
+        -zircon-*,
+        -altera-id-dependent-backward-branch,
+        -altera-unroll-loops,
+        -bugprone-easily-swappable-parameters,
+        -readability-else-after-return,
+        -readability-identifier-length,
+        -readability-static-accessed-through-instance,
+"
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+FormatStyle: none

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -1,0 +1,10 @@
+-Wall
+-Werror
+-Wextra
+-pedantic
+--std=c17
+-g
+-O3
+-pipe
+-Iinclude
+-I/usr/include/python3.13

--- a/include/hutoken/bpe.h
+++ b/include/hutoken/bpe.h
@@ -1,0 +1,6 @@
+#ifndef HUTOKEN_BPE_H
+#define HUTOKEN_BPE_H
+
+void bpe_train(char *text, const int vocab_size, const char *pattern, char *vocab_file_name);
+
+#endif

--- a/include/hutoken/bpe.h
+++ b/include/hutoken/bpe.h
@@ -1,6 +1,14 @@
 #ifndef HUTOKEN_BPE_H
 #define HUTOKEN_BPE_H
 
-void bpe_train(char *text, const int vocab_size, const char *pattern, char *vocab_file_name);
+struct Token {
+    char* key;
+    int value;
+};
+
+void bpe_train(char* text,
+               const int vocab_size,
+               const char* pattern,
+               char* vocab_file_name);
 
 #endif

--- a/include/hutoken/core.h
+++ b/include/hutoken/core.h
@@ -1,0 +1,11 @@
+#ifndef HUTOKEN_CORE_H
+#define HUTOKEN_CORE_H
+
+#include "Python.h"
+
+#include "hashmap.h"
+
+void encode(char *text, struct HashMap *vocab, char *pattern, int tokens[], int *tokens_size);
+PyObject *decode(PyObject *tokens, char **vocab_decode, int vocab_size);
+
+#endif

--- a/include/hutoken/core.h
+++ b/include/hutoken/core.h
@@ -1,11 +1,15 @@
 #ifndef HUTOKEN_CORE_H
 #define HUTOKEN_CORE_H
 
-#include "Python.h"
+#include <Python.h>
 
 #include "hutoken/hashmap.h"
 
-void encode(char *text, struct HashMap *vocab, char *pattern, int tokens[], int *tokens_size);
-PyObject *decode(PyObject *tokens, char **vocab_decode, int vocab_size);
+void encode(char* text,
+            struct HashMap* vocab,
+            char* pattern,
+            int tokens[],
+            int* tokens_size);
+PyObject* decode(PyObject* tokens, char** vocab_decode, int vocab_size);
 
 #endif

--- a/include/hutoken/core.h
+++ b/include/hutoken/core.h
@@ -3,7 +3,7 @@
 
 #include "Python.h"
 
-#include "hashmap.h"
+#include "hutoken/hashmap.h"
 
 void encode(char *text, struct HashMap *vocab, char *pattern, int tokens[], int *tokens_size);
 PyObject *decode(PyObject *tokens, char **vocab_decode, int vocab_size);

--- a/include/hutoken/hash.h
+++ b/include/hutoken/hash.h
@@ -1,0 +1,13 @@
+#ifndef HUTOKEN_HASH_H
+#define HUTOKEN_HASH_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifndef SEED
+    #define SEED 42
+#endif
+
+uint64_t hashmap_murmur(const void *data, size_t len);
+
+#endif

--- a/include/hutoken/hash.h
+++ b/include/hutoken/hash.h
@@ -5,9 +5,9 @@
 #include <stdint.h>
 
 #ifndef SEED
-    #define SEED 42
+#define SEED 42
 #endif
 
-uint64_t hashmap_murmur(const void *data, size_t len);
+uint64_t hashmap_murmur(const void* data, size_t len);
 
 #endif

--- a/include/hutoken/hashmap.h
+++ b/include/hutoken/hashmap.h
@@ -1,0 +1,38 @@
+#ifndef HUTOKEN_HASHMAP_H
+#define HUTOKEN_HASHMAP_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+struct HashMap {
+    size_t element_size;
+    size_t capacity;
+    size_t bucket_size;
+    size_t bucket_num;
+    size_t count;
+    size_t mask;
+    size_t growat;
+    size_t shrinkat; // hash map shrinks if number of items falls below threshold
+    uint8_t loadfactor; // threshold of filled buckets before resizing
+    uint8_t growpower; // how much the hash map will grow when resized
+    bool oom; // signal that last called failed due to system being out of memory.
+    void *buckets;
+    void *spare;
+    void *edata; // temp data for a bucket
+};
+
+struct HashMap *hashmap_new(size_t capacity);
+const void *hashmap_set(struct HashMap *map, const void *item);
+int hashmap_get(struct HashMap *map, const void *key);
+const void *hashmap_delete(struct HashMap *map, const void *key);
+void hashmap_clear(struct HashMap *map, bool update_cap);
+bool hashmap_iter(struct HashMap *map, size_t *i, void **item);
+void hashmap_free(struct HashMap *map);
+
+struct Token {
+    char *key;
+    int value;
+};
+
+#endif

--- a/include/hutoken/hashmap.h
+++ b/include/hutoken/hashmap.h
@@ -13,26 +13,23 @@ struct HashMap {
     size_t count;
     size_t mask;
     size_t growat;
-    size_t shrinkat; // hash map shrinks if number of items falls below threshold
-    uint8_t loadfactor; // threshold of filled buckets before resizing
-    uint8_t growpower; // how much the hash map will grow when resized
-    bool oom; // signal that last called failed due to system being out of memory.
-    void *buckets;
-    void *spare;
-    void *edata; // temp data for a bucket
+    size_t
+        shrinkat;  // hash map shrinks if number of items falls below threshold
+    uint8_t loadfactor;  // threshold of filled buckets before resizing
+    uint8_t growpower;   // how much the hash map will grow when resized
+    bool oom;  // signal that last called failed due to system being out of
+               // memory.
+    void* buckets;
+    void* spare;
+    void* edata;  // temp data for a bucket
 };
 
-struct HashMap *hashmap_new(size_t capacity);
-const void *hashmap_set(struct HashMap *map, const void *item);
-int hashmap_get(struct HashMap *map, const void *key);
-const void *hashmap_delete(struct HashMap *map, const void *key);
-void hashmap_clear(struct HashMap *map, bool update_cap);
-bool hashmap_iter(struct HashMap *map, size_t *i, void **item);
-void hashmap_free(struct HashMap *map);
-
-struct Token {
-    char *key;
-    int value;
-};
+struct HashMap* hashmap_new(size_t capacity);
+const void* hashmap_set(struct HashMap* map, const void* item);
+int hashmap_get(struct HashMap* map, const void* key);
+const void* hashmap_delete(struct HashMap* map, const void* key);
+void hashmap_clear(struct HashMap* map, bool update_cap);
+bool hashmap_iter(struct HashMap* map, size_t* i, void** item);
+void hashmap_free(struct HashMap* map);
 
 #endif

--- a/include/hutoken/helper.h
+++ b/include/hutoken/helper.h
@@ -1,0 +1,27 @@
+#ifndef HUTOKEN_HELPER_H
+#define HUTOKEN_HELPER_H
+
+#include <stddef.h>
+
+#include "hashmap.h"
+
+#define TEXT_SIZE_INCREMENT 50
+
+typedef struct {
+    char *start;
+    char *end;
+} Boundary;
+
+void log_debug(const char *format, ...);
+void visualize(int arr[], char *text, int n);
+void visualize_bpe_train(
+    char* text,
+    Boundary token_boundaries[],
+    struct Token current_token,
+    int value,
+    int token_num
+);
+void hex_str_to_ascii(const char *hex_str, char *ascii_str, size_t ascii_str_size);
+int save_vocab(struct HashMap *vocab, char *file_name);
+
+#endif

--- a/include/hutoken/helper.h
+++ b/include/hutoken/helper.h
@@ -3,7 +3,7 @@
 
 #include <stddef.h>
 
-#include "hashmap.h"
+#include "hutoken/hashmap.h"
 
 #define TEXT_SIZE_INCREMENT 50
 

--- a/include/hutoken/helper.h
+++ b/include/hutoken/helper.h
@@ -3,25 +3,26 @@
 
 #include <stddef.h>
 
+#include "hutoken/bpe.h"
 #include "hutoken/hashmap.h"
 
 #define TEXT_SIZE_INCREMENT 50
 
-typedef struct {
-    char *start;
-    char *end;
-} Boundary;
+struct Boundary {
+    char* start;
+    char* end;
+};
 
-void log_debug(const char *format, ...);
-void visualize(int arr[], char *text, int n);
-void visualize_bpe_train(
-    char* text,
-    Boundary token_boundaries[],
-    struct Token current_token,
-    int value,
-    int token_num
-);
-void hex_str_to_ascii(const char *hex_str, char *ascii_str, size_t ascii_str_size);
-int save_vocab(struct HashMap *vocab, char *file_name);
+void log_debug(const char* format, ...);
+void visualize(int arr[], char* text, int n);
+void visualize_bpe_train(char* text,
+                         struct Boundary token_boundaries[],
+                         struct Token current_token,
+                         size_t value,
+                         size_t token_num);
+void hex_str_to_ascii(const char* hex_str,
+                      char* ascii_str,
+                      size_t ascii_str_size);
+int save_vocab(struct HashMap* vocab, char* file_name);
 
 #endif

--- a/include/hutoken/lib.h
+++ b/include/hutoken/lib.h
@@ -3,8 +3,8 @@
 
 #include <Python.h>
 
-PyObject *p_bpe_train(PyObject *self, PyObject *args);
-PyObject *p_encode(PyObject *self, PyObject *args);
+PyObject* p_bpe_train(PyObject* self, PyObject* args);
+PyObject* p_encode(PyObject* self, PyObject* args);
 PyMODINIT_FUNC PyInit__hutoken(void);
 
 #endif

--- a/include/hutoken/lib.h
+++ b/include/hutoken/lib.h
@@ -1,0 +1,10 @@
+#ifndef HUTOKEN_LIB_H
+#define HUTOKEN_LIB_H
+
+#include <Python.h>
+
+PyObject *p_bpe_train(PyObject *self, PyObject *args);
+PyObject *p_encode(PyObject *self, PyObject *args);
+PyMODINIT_FUNC PyInit__hutoken(void);
+
+#endif

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ setup(
     ext_modules=[
         Extension(
             "_hutoken",
-            ["src/lib.c"],
-            extra_compile_args=["-O3", "-march=native", "-funroll-loops"],
+            ["src/lib.c", "src/bpe.c", "src/core.c", "src/hash.c", "src/hashmap.c", "src/helper.c"],
+            extra_compile_args=["-O3", "-march=native", "-funroll-loops", "-Iinclude"],
             extra_link_args=["-flto"]
         )
     ]

--- a/src/bpe.c
+++ b/src/bpe.c
@@ -1,3 +1,5 @@
+#include "bpe.h"
+
 #include <Python.h>
 
 #include <assert.h>
@@ -7,8 +9,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "helper.c"
-#include "hashmap.c"
+#include "hashmap.h"
+#include "helper.h"
 
 
 void create_words(

--- a/src/bpe.c
+++ b/src/bpe.c
@@ -5,6 +5,7 @@
 #include <assert.h>
 #include <regex.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -12,39 +13,32 @@
 #include "hutoken/hashmap.h"
 #include "hutoken/helper.h"
 
-
-void create_words(
-    char *text,
-    const char *pattern,
-    Boundary token_boundaries[],
-    int token_num
-)
-{
+void create_words(char* text,
+                  const char* pattern,
+                  struct Boundary token_boundaries[],
+                  size_t token_num) {
     regex_t regex;
 
     int r = regcomp(&regex, pattern, REG_EXTENDED);
-    if (r)
-    {
-        fprintf(stderr, "Regex could not be compiled.\n");
+    if (r) {
+        (void)fputs("Regex could not be compiled.", stderr);
         PyErr_SetString(PyExc_RuntimeError, "Regex could not be compiled.");
         return;
     }
 
     regmatch_t match;
-    char *cursor = text;
+    char* cursor = text;
     int i = 0;
 
-    while (regexec(&regex, cursor, 1, &match, 0) == 0)
-    {
+    while (regexec(&regex, cursor, 1, &match, 0) == 0) {
         int word_start = match.rm_so;
         int word_end = match.rm_eo;
 
-        for (char *ptr = cursor + word_start; ptr < cursor + word_end; ptr++) {
+        for (char* ptr = cursor + word_start; ptr < cursor + word_end; ptr++) {
+            char* start = ptr;
+            char* end = ptr;
 
-            char *start = ptr;
-            char *end = ptr;
-
-            Boundary token_boundary = {start, end};
+            struct Boundary token_boundary = {start, end};
 
             token_boundaries[i] = token_boundary;
             i += 1;
@@ -55,35 +49,30 @@ void create_words(
     regfree(&regex);
 }
 
-void bpe_train_core(
-    struct HashMap *vocab,
-    char *text,
-    Boundary token_boundaries[],
-    int token_num,
-    int vocab_size
-)
-{
-    int token_n = token_num;
+void bpe_train_core(struct HashMap* vocab,
+                    char* text,
+                    struct Boundary token_boundaries[],
+                    size_t token_num,
+                    size_t vocab_size) {
+    size_t token_n = token_num;
     struct Token prev_common_pair = {"", -1};
     struct Token most_common_pair = {"", -1};
 
-    while (vocab->count < vocab_size)
-    {
-        struct HashMap *stats = hashmap_new(token_n);
+    while (vocab->count < vocab_size) {
+        struct HashMap* stats = hashmap_new(token_n);
 
         // find most common pair -> next token
 
-        for (int i = 0; i < token_num -1; i++)
-        {
-            char *s1 = token_boundaries[i].start;
-            char *e1 = token_boundaries[i].end;
-            int l1 = (e1 - s1) + 1;
+        for (size_t i = 0; i < token_num - 1; i++) {
+            char* s1 = token_boundaries[i].start;
+            char* e1 = token_boundaries[i].end;
+            ptrdiff_t l1 = (e1 - s1) + 1;
 
-            char *s2 = token_boundaries[i+1].start;
-            char *e2 = token_boundaries[i+1].end;
-            int l2 = (e2 - s2) + 1;
+            char* s2 = token_boundaries[i + 1].start;
+            char* e2 = token_boundaries[i + 1].end;
+            ptrdiff_t l2 = (e2 - s2) + 1;
 
-            int len = l1 + l2;
+            ptrdiff_t len = l1 + l2;
             char pair[len + 1];
 
             strncpy(pair, s1, l1);
@@ -91,62 +80,62 @@ void bpe_train_core(
             pair[len] = '\0';
 
             int freq = hashmap_get(stats, &(struct Token){.key = pair});
-            if (freq)
-            {
-                hashmap_set(stats, &(struct Token){.key = strdup(pair), .value = ++freq});
-            }
-            else
-            {
+            if (freq) {
+                hashmap_set(stats, &(struct Token){.key = strdup(pair),
+                                                   .value = ++freq});
+            } else {
                 int initial_freq = 1;
-                hashmap_set(stats, &(struct Token){.key = strdup(pair), .value = initial_freq});
+                hashmap_set(stats, &(struct Token){.key = strdup(pair),
+                                                   .value = initial_freq});
             }
 
             int rank = hashmap_get(stats, &(struct Token){.key = pair});
 
-            if (most_common_pair.value < rank)
-            {
+            if (most_common_pair.value < rank) {
                 most_common_pair.value = rank;
                 most_common_pair.key = strdup(pair);
             }
         }
 
-        int token = vocab->count + 1;
+        // WARNING: vocab->count is a size_t. If it exceeds INT_MAX, this
+        // assignment will overflow, causing token to become negative. The
+        // Token.value field should ideally be changed to size_t to
+        // support larger vocabs.
+        int token = (int)(vocab->count + 1);
 
         // add new token
 
-        hashmap_set(vocab, &(struct Token){.key=most_common_pair.key, .value=token});
+        hashmap_set(vocab, &(struct Token){.key = most_common_pair.key,
+                                           .value = token});
 
         // merge that most common pair in all tokens, i.e.
         // update token boundaries for the new token everywhere
 
         int j = 0;
-        Boundary new_token_boundaries[token_n];
+        struct Boundary new_token_boundaries[token_n];
 
-        for (int i = 0; i < token_n - 1; i++)
-        {
-            char *s1 = token_boundaries[i].start;
-            char *e1 = token_boundaries[i].end;
-            int l1 = (e1 - s1) + 1;
+        for (size_t i = 0; i < token_n - 1; i++) {
+            char* s1 = token_boundaries[i].start;
+            char* e1 = token_boundaries[i].end;
+            ptrdiff_t l1 = (e1 - s1) + 1;
 
-            char *s2 = token_boundaries[i+1].start;
-            char *e2 = token_boundaries[i+1].end;
-            int l2 = (e2 - s2) + 1;
+            char* s2 = token_boundaries[i + 1].start;
+            char* e2 = token_boundaries[i + 1].end;
+            ptrdiff_t l2 = (e2 - s2) + 1;
 
-            int len = l1 + l2;
+            ptrdiff_t len = l1 + l2;
             char pair[len + 1];
 
             strncpy(pair, s1, l1);
             strncpy(pair + l1, s2, l2);
             pair[len] = '\0';
 
-            if (strcmp(pair, most_common_pair.key) == 0)
-            {
-                Boundary new_token_boundary = {s1, e2};
+            if (strcmp(pair, most_common_pair.key) == 0) {
+                struct Boundary new_token_boundary = {s1, e2};
                 new_token_boundaries[j] = new_token_boundary;
                 j++;
                 i++;
-            }
-            else {
+            } else {
                 new_token_boundaries[j] = token_boundaries[i];
                 j++;
             }
@@ -157,41 +146,42 @@ void bpe_train_core(
         }
         token_n = j;
 
-        visualize_bpe_train(text, token_boundaries, most_common_pair, token, token_n);
+        visualize_bpe_train(text, token_boundaries, most_common_pair, token,
+                            token_n);
 
         hashmap_free(stats);
 
         if (strcmp(prev_common_pair.key, most_common_pair.key) == 0) {
             break;
-        } else {
-            prev_common_pair.key = most_common_pair.key;
-            prev_common_pair.value = most_common_pair.value;
         }
+
+        prev_common_pair.key = most_common_pair.key;
+        prev_common_pair.value = most_common_pair.value;
 
         most_common_pair.value = -1;
         most_common_pair.key = "\0";
     }
 }
 
-
-void bpe_train(char *text, const int vocab_size, const char *pattern, char *vocab_file_name)
-{
-    char *k;
-    struct HashMap *vocab = hashmap_new(vocab_size);
+void bpe_train(char* text,
+               const int vocab_size,
+               const char* pattern,
+               char* vocab_file_name) {
+    char* k = NULL;
+    struct HashMap* vocab = hashmap_new(vocab_size);
 
     // add tokens for each individual byte value
-    for (int i = 0; i < 256; i++)
-    {
+    for (int i = 0; i < 256; i++) {
         char key[2];
-        key[0] = (char)i; // store ascii character
+        key[0] = (char)i;  // store ascii character
         key[1] = '\0';
 
         k = strdup(key);
         hashmap_set(vocab, &(struct Token){.key = k, .value = i});
     }
 
-    int token_num = strlen(text);
-    Boundary token_boundaries[token_num];
+    size_t token_num = strlen(text);
+    struct Boundary token_boundaries[token_num];
 
     create_words(text, pattern, token_boundaries, token_num);
 

--- a/src/bpe.c
+++ b/src/bpe.c
@@ -1,11 +1,11 @@
 #include <Python.h>
 
+#include <assert.h>
+#include <regex.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdbool.h>
-#include <assert.h>
-#include <regex.h>
 
 #include "helper.c"
 #include "hashmap.c"

--- a/src/bpe.c
+++ b/src/bpe.c
@@ -1,4 +1,4 @@
-#include "bpe.h"
+#include "hutoken/bpe.h"
 
 #include <Python.h>
 
@@ -9,8 +9,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "hashmap.h"
-#include "helper.h"
+#include "hutoken/hashmap.h"
+#include "hutoken/helper.h"
 
 
 void create_words(

--- a/src/core.c
+++ b/src/core.c
@@ -1,3 +1,5 @@
+#include "core.h"
+
 #include <Python.h>
 
 #include <assert.h>
@@ -9,8 +11,8 @@
 #include <string.h>
 #include <time.h>
 
-#include "helper.c"
-#include "hashmap.c"
+#include "hashmap.h"
+#include "helper.h"
 
 void bpe_encode(struct HashMap *vocab, Boundary token_boundaries[], int tokens[], int *token_num)
 {

--- a/src/core.c
+++ b/src/core.c
@@ -6,6 +6,7 @@
 #include <regex.h>
 #include <stdarg.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -14,24 +15,24 @@
 #include "hutoken/hashmap.h"
 #include "hutoken/helper.h"
 
-void bpe_encode(struct HashMap *vocab, Boundary token_boundaries[], int tokens[], int *token_num)
-{
-    while (1)
-    {
+void bpe_encode(struct HashMap* vocab,
+                struct Boundary token_boundaries[],
+                int tokens[],
+                int* token_num) {
+    while (1) {
         int min_idx = -1;
         int min_rank = -1;
 
-        for (int i = 0; i < *token_num - 1; i++)
-        {
-            char *s1 = token_boundaries[i].start;
-            char *e1 = token_boundaries[i].end;
-            int l1 = (e1 - s1) + 1;
+        for (int i = 0; i < *token_num - 1; i++) {
+            char* s1 = token_boundaries[i].start;
+            char* e1 = token_boundaries[i].end;
+            ptrdiff_t l1 = (e1 - s1) + 1;
 
-            char *s2 = token_boundaries[i + 1].start;
-            char *e2 = token_boundaries[i + 1].end;
-            int l2 = (e2 - s2) + 1;
+            char* s2 = token_boundaries[i + 1].start;
+            char* e2 = token_boundaries[i + 1].end;
+            ptrdiff_t l2 = (e2 - s2) + 1;
 
-            int len = l1 + l2;
+            ptrdiff_t len = l1 + l2;
             char pair[len + 1];
 
             strncpy(pair, s1, l1);
@@ -40,23 +41,23 @@ void bpe_encode(struct HashMap *vocab, Boundary token_boundaries[], int tokens[]
 
             int rank = hashmap_get(vocab, &(struct Token){.key = pair});
 
-            if (rank != -1 && (min_rank == -1 || rank < min_rank))
-            {
+            if (rank != -1 && (min_rank == -1 || rank < min_rank)) {
                 min_idx = i;
                 min_rank = rank;
             }
         }
 
         // no pairs to merge
-        if (min_rank == -1)
+        if (min_rank == -1) {
             break;
+        }
+
         assert(min_idx != -1);
 
         // merge pairs, leave rest unchanged
         token_boundaries[min_idx].end = token_boundaries[min_idx + 1].end;
 
-        for (int i = min_idx + 1; i < *token_num - 1; i++)
-        {
+        for (int i = min_idx + 1; i < *token_num - 1; i++) {
             token_boundaries[i].start = token_boundaries[i + 1].start;
             token_boundaries[i].end = token_boundaries[i + 1].end;
         }
@@ -64,11 +65,10 @@ void bpe_encode(struct HashMap *vocab, Boundary token_boundaries[], int tokens[]
     }
 
     // update tokens
-    for (int i = 0; i < *token_num; i++)
-    {
-        char *start = token_boundaries[i].start;
-        char *end = token_boundaries[i].end;
-        int len = (end - start) + 1;
+    for (int i = 0; i < *token_num; i++) {
+        char* start = token_boundaries[i].start;
+        char* end = token_boundaries[i].end;
+        ptrdiff_t len = (end - start) + 1;
 
         char string[len + 1];
         strncpy(string, start, len);
@@ -80,7 +80,11 @@ void bpe_encode(struct HashMap *vocab, Boundary token_boundaries[], int tokens[]
     }
 }
 
-void encode(char *text, struct HashMap *vocab, char *pattern, int tokens[], int *tokens_size) {
+void encode(char* text,
+            struct HashMap* vocab,
+            char* pattern,
+            int tokens[],
+            int* tokens_size) {
     log_debug("Starting encode function with text: %s", text);
 
     regex_t regex;
@@ -92,22 +96,23 @@ void encode(char *text, struct HashMap *vocab, char *pattern, int tokens[], int 
     }
 
     regmatch_t match;
-    char *cursor = text;
+    char* cursor = text;
 
     while (regexec(&regex, cursor, 1, &match, 0) == 0) {
         int word_start = match.rm_so;
         int word_end = match.rm_eo;
         int word_len = word_end - word_start;
 
-        log_debug("Matched word: start=%d, end=%d, length=%d", word_start, word_end, word_len);
+        log_debug("Matched word: start=%d, end=%d, length=%d", word_start,
+                  word_end, word_len);
 
         int i = 0;
-        Boundary word_token_boundaries[word_len];
+        struct Boundary word_token_boundaries[word_len];
 
-        for (char *ptr = cursor + word_start; ptr < cursor + word_end; ptr++) {
-            char *start = ptr;
-            char *end = ptr;
-            Boundary word_token_boundary = {start, end};
+        for (char* ptr = cursor + word_start; ptr < cursor + word_end; ptr++) {
+            char* start = ptr;
+            char* end = ptr;
+            struct Boundary word_token_boundary = {start, end};
             word_token_boundaries[i] = word_token_boundary;
             i += 1;
         }
@@ -130,15 +135,14 @@ void encode(char *text, struct HashMap *vocab, char *pattern, int tokens[], int 
     log_debug("Completed encode function. Total tokens: %d", *tokens_size);
 }
 
-PyObject *decode(PyObject *tokens, char **vocab_decode, int vocab_size)
-{
+PyObject* decode(PyObject* tokens, char** vocab_decode, int vocab_size) {
     log_debug("Entered decode function");
 
     Py_ssize_t token_num = PyList_Size(tokens);
     log_debug("Number of tokens to decode: %zd", token_num);
 
     size_t text_size = sizeof(char) * ((int)token_num + 1);
-    char *text = (char *)malloc(text_size);
+    char* text = (char*)malloc(text_size);
 
     if (!text) {
         log_debug("Error: Memory allocation failed for text buffer");
@@ -146,37 +150,48 @@ PyObject *decode(PyObject *tokens, char **vocab_decode, int vocab_size)
     }
 
     text[0] = '\0';
-    log_debug("Initialized text buffer to an empty string (size: %zu bytes)", text_size);
+    log_debug("Initialized text buffer to an empty string (size: %zu bytes)",
+              text_size);
 
     for (Py_ssize_t i = 0; i < token_num; i++) {
         log_debug("Processing token at index %zd", i);
 
-        PyObject *token = PyList_GetItem(tokens, i);
+        PyObject* token = PyList_GetItem(tokens, i);
         if (!PyLong_Check(token)) {
             log_debug("Error: Token at index %zd is not an integer", i);
-            PyErr_SetString(PyExc_TypeError, "All elements of the list must be integers");
+            PyErr_SetString(PyExc_TypeError,
+                            "All elements of the list must be integers");
             free(text);
             return NULL;
         }
 
         int item = (int)PyLong_AsLong(token);
         if (item < 0 || item >= vocab_size) {
-            log_debug("Error: Token value %d is out of bounds (vocab_size = %d)", item, vocab_size);
-            PyErr_SetString(PyExc_ValueError, "Element must be non-negative and less than vocab size.");
+            log_debug(
+                "Error: Token value %d is out of bounds (vocab_size = %d)",
+                item, vocab_size);
+            PyErr_SetString(
+                PyExc_ValueError,
+                "Element must be non-negative and less than vocab size.");
             free(text);
             return NULL;
         }
 
-        const char *word = vocab_decode[item];
+        const char* word = vocab_decode[item];
         size_t word_len = strlen(word);
-        log_debug("Decoded token value %d to word '%s' (length: %zu)", item, word, word_len);
+        log_debug("Decoded token value %d to word '%s' (length: %zu)", item,
+                  word, word_len);
 
         size_t current_len = strlen(text);
         if (current_len + word_len + 1 >= text_size) {
-            log_debug("Resizing text buffer: current length = %zu, word length = %zu, current buffer size = %zu", current_len, word_len, text_size);
+            log_debug(
+                "Resizing text buffer: current length = %zu, word length = "
+                "%zu, current buffer size = %zu",
+                current_len, word_len, text_size);
 
-            int buffer_size = current_len + TEXT_SIZE_INCREMENT + word_len + 1;
-            char *new_text = realloc(text, buffer_size);
+            size_t buffer_size =
+                current_len + TEXT_SIZE_INCREMENT + word_len + 1;
+            char* new_text = realloc(text, buffer_size);
 
             if (new_text == NULL) {
                 log_debug("Error: Memory reallocation failed for text buffer");
@@ -190,17 +205,21 @@ PyObject *decode(PyObject *tokens, char **vocab_decode, int vocab_size)
         }
 
         strcat(text, word);
-        log_debug("Appended word '%s' to text buffer. Current text: '%s' (buffer size: %zu bytes)", word, text, text_size);
+        log_debug(
+            "Appended word '%s' to text buffer. Current text: '%s' (buffer "
+            "size: %zu bytes)",
+            word, text, text_size);
     }
 
-    PyObject *result = PyUnicode_FromString(text);
+    PyObject* result = PyUnicode_FromString(text);
     if (!result) {
         log_debug("Error: Failed to create Python string from decoded text");
         free(text);
         return NULL;
     }
 
-    log_debug("Successfully created Python string from decoded text: '%s'", text);
+    log_debug("Successfully created Python string from decoded text: '%s'",
+              text);
 
     free(text);
     return result;

--- a/src/core.c
+++ b/src/core.c
@@ -1,4 +1,4 @@
-#include "core.h"
+#include "hutoken/core.h"
 
 #include <Python.h>
 
@@ -11,8 +11,8 @@
 #include <string.h>
 #include <time.h>
 
-#include "hashmap.h"
-#include "helper.h"
+#include "hutoken/hashmap.h"
+#include "hutoken/helper.h"
 
 void bpe_encode(struct HashMap *vocab, Boundary token_boundaries[], int tokens[], int *token_num)
 {

--- a/src/core.c
+++ b/src/core.c
@@ -1,13 +1,13 @@
 #include <Python.h>
 
+#include <assert.h>
+#include <regex.h>
+#include <stdarg.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdbool.h>
-#include <assert.h>
-#include <regex.h>
 #include <time.h>
-#include <stdarg.h>
 
 #include "helper.c"
 #include "hashmap.c"

--- a/src/hash.c
+++ b/src/hash.c
@@ -1,4 +1,4 @@
-#include "hash.h"
+#include "hutoken/hash.h"
 
 #include <stddef.h>
 #include <stdint.h>

--- a/src/hash.c
+++ b/src/hash.c
@@ -1,3 +1,5 @@
+#include "hash.h"
+
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -5,9 +7,6 @@
 #include <string.h>
 
 
-#ifndef SEED
-    #define SEED 42
-#endif
 
 
 //-----------------------------------------------------------------------------

--- a/src/hash.c
+++ b/src/hash.c
@@ -6,20 +6,22 @@
 #include <stdlib.h>
 #include <string.h>
 
-
-
-
 //-----------------------------------------------------------------------------
 // MurmurHash3 was written by Austin Appleby, and is placed in the public
 // domain. The author hereby disclaims copyright to this source code.
 //
 // Murmur3_86_128
 //-----------------------------------------------------------------------------
-static uint64_t MM86128(const void *key, const int len) {
-#define	ROTL32(x, r) ((x << r) | (x >> (32 - r)))
-#define FMIX32(h) h^=h>>16; h*=0x85ebca6b; h^=h>>13; h*=0xc2b2ae35; h^=h>>16;
-    const uint8_t * data = (const uint8_t*)key;
-    const int nblocks = len / 16;
+static uint64_t MM86128(const void* key, const size_t len) {
+#define ROTL32(x, r) (((x) << (r)) | ((x) >> (32 - (r))))
+#define FMIX32(h)      \
+    h ^= (h) >> 16;    \
+    (h) *= 0x85ebca6b; \
+    (h) ^= (h) >> 13;  \
+    (h) *= 0xc2b2ae35; \
+    (h) ^= (h) >> 16;
+    const uint8_t* data = (const uint8_t*)key;
+    const size_t nblocks = len / 16;
     uint32_t h1 = SEED;
     uint32_t h2 = SEED;
     uint32_t h3 = SEED;
@@ -28,63 +30,123 @@ static uint64_t MM86128(const void *key, const int len) {
     uint32_t c2 = 0xab0e9789;
     uint32_t c3 = 0x38b34ae5;
     uint32_t c4 = 0xa1e38b93;
-    const uint32_t * blocks = (const uint32_t *)(data + nblocks*16);
-    for (int i = -nblocks; i; i++) {
-        uint32_t k1 = blocks[i*4+0];
-        uint32_t k2 = blocks[i*4+1];
-        uint32_t k3 = blocks[i*4+2];
-        uint32_t k4 = blocks[i*4+3];
-        k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
-        h1 = ROTL32(h1,19); h1 += h2; h1 = h1*5+0x561ccd1b;
-        k2 *= c2; k2  = ROTL32(k2,16); k2 *= c3; h2 ^= k2;
-        h2 = ROTL32(h2,17); h2 += h3; h2 = h2*5+0x0bcaa747;
-        k3 *= c3; k3  = ROTL32(k3,17); k3 *= c4; h3 ^= k3;
-        h3 = ROTL32(h3,15); h3 += h4; h3 = h3*5+0x96cd1c35;
-        k4 *= c4; k4  = ROTL32(k4,18); k4 *= c1; h4 ^= k4;
-        h4 = ROTL32(h4,13); h4 += h1; h4 = h4*5+0x32ac3b17;
+    const uint32_t* blocks =
+        (const uint32_t*)(data + (ptrdiff_t)(nblocks * 16));
+    for (size_t i = -nblocks; i; i++) {
+        uint32_t k1 = blocks[i * 4 + 0];
+        uint32_t k2 = blocks[i * 4 + 1];
+        uint32_t k3 = blocks[i * 4 + 2];
+        uint32_t k4 = blocks[i * 4 + 3];
+        k1 *= c1;
+        k1 = ROTL32(k1, 15);
+        k1 *= c2;
+        h1 ^= k1;
+        h1 = ROTL32(h1, 19);
+        h1 += h2;
+        h1 = h1 * 5 + 0x561ccd1b;
+        k2 *= c2;
+        k2 = ROTL32(k2, 16);
+        k2 *= c3;
+        h2 ^= k2;
+        h2 = ROTL32(h2, 17);
+        h2 += h3;
+        h2 = h2 * 5 + 0x0bcaa747;
+        k3 *= c3;
+        k3 = ROTL32(k3, 17);
+        k3 *= c4;
+        h3 ^= k3;
+        h3 = ROTL32(h3, 15);
+        h3 += h4;
+        h3 = h3 * 5 + 0x96cd1c35;
+        k4 *= c4;
+        k4 = ROTL32(k4, 18);
+        k4 *= c1;
+        h4 ^= k4;
+        h4 = ROTL32(h4, 13);
+        h4 += h1;
+        h4 = h4 * 5 + 0x32ac3b17;
     }
-    const uint8_t * tail = (const uint8_t*)(data + nblocks*16);
+    const uint8_t* tail = data + (ptrdiff_t)(nblocks * 16);
     uint32_t k1 = 0;
     uint32_t k2 = 0;
     uint32_t k3 = 0;
     uint32_t k4 = 0;
-    switch(len & 15) {
-    case 15: k4 ^= tail[14] << 16; /* fall through */
-    case 14: k4 ^= tail[13] << 8; /* fall through */
-    case 13: k4 ^= tail[12] << 0;
-             k4 *= c4; k4  = ROTL32(k4,18); k4 *= c1; h4 ^= k4;
-             /* fall through */
-    case 12: k3 ^= tail[11] << 24; /* fall through */
-    case 11: k3 ^= tail[10] << 16; /* fall through */
-    case 10: k3 ^= tail[ 9] << 8; /* fall through */
-    case  9: k3 ^= tail[ 8] << 0;
-             k3 *= c3; k3  = ROTL32(k3,17); k3 *= c4; h3 ^= k3;
-             /* fall through */
-    case  8: k2 ^= tail[ 7] << 24; /* fall through */
-    case  7: k2 ^= tail[ 6] << 16; /* fall through */
-    case  6: k2 ^= tail[ 5] << 8; /* fall through */
-    case  5: k2 ^= tail[ 4] << 0;
-             k2 *= c2; k2  = ROTL32(k2,16); k2 *= c3; h2 ^= k2;
-             /* fall through */
-    case  4: k1 ^= tail[ 3] << 24; /* fall through */
-    case  3: k1 ^= tail[ 2] << 16; /* fall through */
-    case  2: k1 ^= tail[ 1] << 8; /* fall through */
-    case  1: k1 ^= tail[ 0] << 0;
-             k1 *= c1; k1  = ROTL32(k1,15); k1 *= c2; h1 ^= k1;
-             /* fall through */
+    switch (len & 15) {
+        case 15:
+            k4 ^= tail[14] << 16; /* fall through */
+        case 14:
+            k4 ^= tail[13] << 8; /* fall through */
+        case 13:
+            k4 ^= tail[12] << 0;
+            k4 *= c4;
+            k4 = ROTL32(k4, 18);
+            k4 *= c1;
+            h4 ^= k4;
+            /* fall through */
+        case 12:
+            k3 ^= tail[11] << 24; /* fall through */
+        case 11:
+            k3 ^= tail[10] << 16; /* fall through */
+        case 10:
+            k3 ^= tail[9] << 8; /* fall through */
+        case 9:
+            k3 ^= tail[8] << 0;
+            k3 *= c3;
+            k3 = ROTL32(k3, 17);
+            k3 *= c4;
+            h3 ^= k3;
+            /* fall through */
+        case 8:
+            k2 ^= tail[7] << 24; /* fall through */
+        case 7:
+            k2 ^= tail[6] << 16; /* fall through */
+        case 6:
+            k2 ^= tail[5] << 8; /* fall through */
+        case 5:
+            k2 ^= tail[4] << 0;
+            k2 *= c2;
+            k2 = ROTL32(k2, 16);
+            k2 *= c3;
+            h2 ^= k2;
+            /* fall through */
+        case 4:
+            k1 ^= tail[3] << 24; /* fall through */
+        case 3:
+            k1 ^= tail[2] << 16; /* fall through */
+        case 2:
+            k1 ^= tail[1] << 8; /* fall through */
+        case 1:
+            k1 ^= tail[0] << 0;
+            k1 *= c1;
+            k1 = ROTL32(k1, 15);
+            k1 *= c2;
+            h1 ^= k1;
+            /* fall through */
     };
-    h1 ^= len; h2 ^= len; h3 ^= len; h4 ^= len;
-    h1 += h2; h1 += h3; h1 += h4;
-    h2 += h1; h3 += h1; h4 += h1;
-    FMIX32(h1); FMIX32(h2); FMIX32(h3); FMIX32(h4);
-    h1 += h2; h1 += h3; h1 += h4;
-    h2 += h1; h3 += h1; h4 += h1;
-    return (((uint64_t)h2)<<32)|h1;
+    h1 ^= len;
+    h2 ^= len;
+    h3 ^= len;
+    h4 ^= len;
+    h1 += h2;
+    h1 += h3;
+    h1 += h4;
+    h2 += h1;
+    h3 += h1;
+    h4 += h1;
+    FMIX32(h1);
+    FMIX32(h2);
+    FMIX32(h3);
+    FMIX32(h4);
+    h1 += h2;
+    h1 += h3;
+    h1 += h4;
+    h2 += h1;
+    h3 += h1;
+    h4 += h1;
+    return (((uint64_t)h2) << 32) | h1;
 }
 
-
 // hashmap_murmur returns a hash value for `data` using Murmur3_86_128.
-uint64_t hashmap_murmur(const void *data, size_t len)
-{
+uint64_t hashmap_murmur(const void* data, size_t len) {
     return MM86128(data, len);
 }

--- a/src/hash.c
+++ b/src/hash.c
@@ -1,8 +1,8 @@
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 
 #ifndef SEED

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -3,12 +3,12 @@
 #define HASHMAP
 
 
-#include <stdio.h>
-#include <string.h>
-#include <stdlib.h>
-#include <stdint.h>
-#include <stddef.h>
 #include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #include "hash.c"
 

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -1,7 +1,4 @@
-
-#ifndef HASHMAP
-#define HASHMAP
-
+#include "hashmap.h"
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -10,37 +7,13 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "hash.c"
-
+#include "hash.h"
 
 #define GROW_AT   0.60 /* 60% */
 #define SHRINK_AT 0.10 /* 10% */
 #define HASHMAP_LOAD_FACTOR 0.60 /* 60% */
 
-
 // Open addressed hash map using robinhood hashing
-struct HashMap {
-    size_t element_size;
-    size_t capacity;
-    size_t bucket_size;
-    size_t bucket_num;
-    size_t count;
-    size_t mask;
-    size_t growat;
-    size_t shrinkat; // hash map shrinks if number of items falls below threshold
-    uint8_t loadfactor; // threshold of filled buckets before resizing
-    uint8_t growpower; // how much the hash map will grow when resized
-    bool oom; // signal that last called failed due to system being out of memory.
-    void *buckets;
-    void *spare;
-    void *edata; // temp data for a bucket
-};
-
-struct Token {
-    char *key;
-    int value;
-};
-
 int compare(const void *a, const void *b) {
     const struct Token *ua = a;
     const struct Token *ub = b;
@@ -415,6 +388,3 @@ void hashmap_free(struct HashMap *map) {
     free(map->buckets);
     free(map);
 }
-
-
-#endif

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -1,4 +1,4 @@
-#include "hashmap.h"
+#include "hutoken/hashmap.h"
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -7,7 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "hash.h"
+#include "hutoken/hash.h"
 
 #define GROW_AT   0.60 /* 60% */
 #define SHRINK_AT 0.10 /* 10% */

--- a/src/helper.c
+++ b/src/helper.c
@@ -1,4 +1,4 @@
-#include "helper.h"
+#include "hutoken/helper.h"
 
 #include <Python.h>
 
@@ -12,7 +12,7 @@
 #include <string.h>
 #include <sys/stat.h>
 
-#include "hashmap.h"
+#include "hutoken/hashmap.h"
 
 #define VISUALIZE 1
 

--- a/src/helper.c
+++ b/src/helper.c
@@ -16,60 +16,56 @@
 
 #define VISUALIZE 1
 
-void log_debug(const char *format, ...) {
-    const char *debug_env = getenv("DEBUG");
+void log_debug(const char* format, ...) {
+    const char* debug_env = getenv("DEBUG");  // NOLINT: concurrency-mt-unsafe
     if (debug_env && strcmp(debug_env, "1") == 0) {
         time_t now = time(NULL);
-        struct tm *local_time = localtime(&now);
+        struct tm* local_time =
+            localtime(&now);  // NOLINT: concurrency-mt-unsafe
         char timestamp[20];
-        strftime(timestamp, sizeof(timestamp), "%Y-%m-%d %H:%M:%S", local_time);
+        (void)strftime(timestamp, sizeof(timestamp), "%Y-%m-%d %H:%M:%S",
+                       local_time);
 
-        fprintf(stderr, "[%s] DEBUG: ", timestamp);
+        (void)fprintf(stderr, "[%s] DEBUG: ", timestamp);
 
         va_list args;
         va_start(args, format);
-        vfprintf(stderr, format, args);
+        (void)vfprintf(stderr, format, args);
         va_end(args);
 
-        fprintf(stderr, "\n");
+        (void)fputs("", stderr);
     }
 }
 
-void visualize(int arr[], char *text, int n)
-{
-
-    if (VISUALIZE)
-    {
+void visualize(int arr[], char* text, int n) {
+    if (VISUALIZE) {
         printf("Processing:\n");
-        for (int i = 0; i < n; i++)
-        {
+        for (int i = 0; i < n; i++) {
             printf("%c ", text[i]);
         }
         printf("\n");
-        for (int i = 0; i < n; i++)
-        {
+        for (int i = 0; i < n; i++) {
             printf("%d ", arr[i]);
         }
         printf("\n");
     }
 }
 
-void visualize_bpe_train(
-    char* text,
-    Boundary token_boundaries[],
-    struct Token current_token,
-    int value,
-    int token_num
-)
-{
-    if (VISUALIZE)
-    {
-        printf("Most common pair: '%s', rank: %d\n", current_token.key, current_token.value);
-        printf("New token '%s', value: %d\n\n", current_token.key, value);
+void visualize_bpe_train(char* text,
+                         struct Boundary token_boundaries[],
+                         struct Token current_token,
+                         size_t value,
+                         size_t token_num) {
+    if (VISUALIZE) {
+        printf("Most common pair: '%s', rank: %d\n", current_token.key,
+               current_token.value);
+        printf("New token '%s', value: %ld\n\n", current_token.key, value);
     }
 }
 
-void hex_str_to_ascii(const char *hex_str, char *ascii_str, size_t ascii_str_size) {
+void hex_str_to_ascii(const char* hex_str,
+                      char* ascii_str,
+                      size_t ascii_str_size) {
     log_debug("Starting hex_str_to_ascii with input: %s", hex_str);
 
     size_t i = 0;
@@ -78,24 +74,32 @@ void hex_str_to_ascii(const char *hex_str, char *ascii_str, size_t ascii_str_siz
             hex_str += 2;
 
             if (hex_str[0] != '\0' && hex_str[1] != '\0') {
-                char hexValue[3] = { hex_str[0], hex_str[1], '\0' };
+                char hexValue[3] = {hex_str[0], hex_str[1], '\0'};
                 int charValue = (int)strtol(hexValue, NULL, 16);
 
-                log_debug("Parsed hex value: %s -> ASCII char: %c (decimal: %d)", hexValue, (char)charValue, charValue);
+                log_debug(
+                    "Parsed hex value: %s -> ASCII char: %c (decimal: %d)",
+                    hexValue, (char)charValue, charValue);
 
                 if (i >= ascii_str_size - 1) {
-                    log_debug("Error: Output buffer overflow in hex_str_to_ascii. Buffer size: %zu, Current index: %zu", ascii_str_size, i);
-                    PyErr_SetString(PyExc_BufferError, "Output buffer overflow in hex_str_to_ascii");
+                    log_debug(
+                        "Error: Output buffer overflow in hex_str_to_ascii. "
+                        "Buffer size: %zu, Current index: %zu",
+                        ascii_str_size, i);
+                    PyErr_SetString(
+                        PyExc_BufferError,
+                        "Output buffer overflow in hex_str_to_ascii");
                     ascii_str[0] = '\0';
                     return;
                 }
 
                 ascii_str[i++] = (char)charValue;
             } else {
-                log_debug("Error: Incomplete hex pair at position: %s", hex_str);
+                log_debug("Error: Incomplete hex pair at position: %s",
+                          hex_str);
             }
 
-            hex_str += 2; 
+            hex_str += 2;
         } else {
             log_debug("Skipping non-hex character: %c", *hex_str);
             hex_str++;
@@ -106,25 +110,24 @@ void hex_str_to_ascii(const char *hex_str, char *ascii_str, size_t ascii_str_siz
     log_debug("Completed hex_str_to_ascii. Result: %s", ascii_str);
 }
 
-int save_vocab(struct HashMap *vocab, char *file_name) {
-
-    const char *home_dir = getenv("HOME");
+int save_vocab(struct HashMap* vocab, char* file_name) {
+    const char* home_dir = getenv("HOME");  // NOLINT: concurrency-mt-unsafe
 
     if (home_dir == NULL) {
-        fprintf(stderr, "Unable to get HOME environment variable.\n");
+        (void)fputs("Unable to get HOME environment variable.", stderr);
         return EXIT_FAILURE;
     }
 
     char dir_path[1024];
-    snprintf(dir_path, sizeof(dir_path), "%s/config", home_dir);
+    (void)snprintf(dir_path, sizeof(dir_path), "%s/config", home_dir);
 
     struct stat st = {0};
     if (stat(dir_path, &st) == -1) {
         if (mkdir(dir_path, 0700) == 0) {
             printf("Directory created: %s\n", dir_path);
         } else {
-            fprintf(stderr, "Error creating directory.\n");
-            fprintf(stderr, "Failed to save vocab.\n");
+            (void)fputs("Error creating directory.", stderr);
+            (void)fputs("Failed to save vocab.", stderr);
             return -1;
         }
     } else {
@@ -132,29 +135,28 @@ int save_vocab(struct HashMap *vocab, char *file_name) {
     }
 
     char file_path[1024];
-    snprintf(file_path, sizeof(file_path), "%s/%s", dir_path, file_name);
+    (void)snprintf(file_path, sizeof(file_path), "%s/%s", dir_path, file_name);
 
-    FILE *file = fopen(file_path, "w");
+    FILE* file = fopen(file_path, "w");
     if (file == NULL) {
         perror("Error creating file.\n");
         return EXIT_FAILURE;
     }
 
     size_t iter = 0;
-    void *item;
-    while (hashmap_iter(vocab, &iter, &item))
-    {
-        const struct Token *token = item;
-        if (!strlen(token->key)) { // handle null character explicitly
-            fprintf(file, "0x00");
+    void* item = NULL;
+    while (hashmap_iter(vocab, &iter, &item)) {
+        const struct Token* token = item;
+        if (!strlen(token->key)) {  // handle null character explicitly
+            (void)fprintf(file, "0x00");
         }
-        for (const char *ptr = token->key; *ptr != '\0'; ptr++) {
-            fprintf(file, "0x%02X", (unsigned char)*ptr);
+        for (const char* ptr = token->key; *ptr != '\0'; ptr++) {
+            (void)fprintf(file, "0x%02X", (unsigned char)*ptr);
         }
-        fprintf(file, " == %d\n", token->value);
+        (void)fprintf(file, " == %d\n", token->value);
     }
 
-    fclose(file);
+    (void)fclose(file);
 
     printf("Vocab saved to: %s\n", file_path);
 

--- a/src/helper.c
+++ b/src/helper.c
@@ -1,5 +1,4 @@
-#ifndef HELPER
-#define HELPER
+#include "helper.h"
 
 #include <Python.h>
 
@@ -13,16 +12,9 @@
 #include <string.h>
 #include <sys/stat.h>
 
-#include "hashmap.c"
+#include "hashmap.h"
 
 #define VISUALIZE 1
-#define TEXT_SIZE_INCREMENT 50
-
-
-typedef struct {
-    char *start;
-    char *end;
-} Boundary;
 
 void log_debug(const char *format, ...) {
     const char *debug_env = getenv("DEBUG");
@@ -168,5 +160,3 @@ int save_vocab(struct HashMap *vocab, char *file_name) {
 
     return EXIT_SUCCESS;
 }
-
-#endif

--- a/src/helper.c
+++ b/src/helper.c
@@ -7,10 +7,10 @@
 #define PyExc_BufferError PyExc_RuntimeError
 #endif
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdbool.h>
 #include <sys/stat.h>
 
 #include "hashmap.c"

--- a/src/lib.c
+++ b/src/lib.c
@@ -10,35 +10,35 @@
 #include "hutoken/core.h"
 #include "hutoken/helper.h"
 
-
 static bool initialized_encode = false;
 static bool initialized_decode = false;
-static char *pattern = "[ ]?[A-Za-záéíóúőűüöÁÉÍÓÚŐÜŰÖ]+|[ ]?[0-9]+|[ ]?[^[:space:][:alpha:][:digit:]]+|[ ]+";
+static char* pattern =
+    "[ ]?[A-Za-záéíóúőűüöÁÉÍÓÚŐÜŰÖ]+|[ ]?[0-9]+|[ "
+    "]?[^[:space:][:alpha:][:digit:]]+|[ ]+";
 
-struct HashMap *vocab_encode;
-char **vocab_decode;
+struct HashMap* vocab_encode;
+char** vocab_decode;
 int vocab_size_decode;
-#define MAX_LINE_LENGTH 10000 
+#define MAX_LINE_LENGTH 10000
 
-
-
-PyObject *p_bpe_train(PyObject *self, PyObject *args)
-{
-
-    char *data;
-    char *vocab_file_name;
+PyObject* p_bpe_train(PyObject* self, PyObject* args) {
+    char* data = NULL;
+    char* vocab_file_name = NULL;
     int vocab_size = 256;
 
-    if (!PyArg_ParseTuple(args, "sis", &data, &vocab_size, &vocab_file_name))
-        return NULL;
-
-    if (vocab_size < 256) {
-        PyErr_SetString(PyExc_RuntimeError,"vocab_size must be at least 256 to encode all bytes.");
+    if (!PyArg_ParseTuple(args, "sis", &data, &vocab_size, &vocab_file_name)) {
         return NULL;
     }
-    int len = strlen(vocab_file_name);
+
+    if (vocab_size < 256) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "vocab_size must be at least 256 to encode all bytes.");
+        return NULL;
+    }
+    size_t len = strlen(vocab_file_name);
     if (len < 4 || strcmp(vocab_file_name + (len - 4), ".txt") != 0) {
-        PyErr_SetString(PyExc_RuntimeError, "vocab_file_name file extension must be .txt.");
+        PyErr_SetString(PyExc_RuntimeError,
+                        "vocab_file_name file extension must be .txt.");
         return NULL;
     }
 
@@ -47,15 +47,21 @@ PyObject *p_bpe_train(PyObject *self, PyObject *args)
     return Py_None;
 }
 
-static PyObject *p_initialize(PyObject *self, PyObject *args, PyObject *kwargs) {
-    static char *kwlist[] = {"vocab_file_path", "special_token_id", NULL};
-    char *vocab_file_path;
-    int special_token_id = -1; // Optional parameter for special token ID
+static PyObject* p_initialize(PyObject* self,
+                              PyObject* args,
+                              PyObject* kwargs) {
+    static char* kwlist[] = {"vocab_file_path", "special_token_id", NULL};
+    char* vocab_file_path = NULL;
+    int special_token_id = -1;  // Optional parameter for special token ID
 
     // Parse arguments
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s|i", kwlist, &vocab_file_path, &special_token_id)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s|i", kwlist,
+                                     &vocab_file_path, &special_token_id)) {
         log_debug("Error: Invalid arguments passed to initialize.");
-        PyErr_SetString(PyExc_TypeError, "Invalid arguments. Expected a string (vocab_file_path) and an optional integer (special_token_id).");
+        PyErr_SetString(
+            PyExc_TypeError,
+            "Invalid arguments. Expected a string (vocab_file_path) and an "
+            "optional integer (special_token_id).");
         return NULL;
     }
 
@@ -65,23 +71,25 @@ static PyObject *p_initialize(PyObject *self, PyObject *args, PyObject *kwargs) 
     vocab_encode = hashmap_new(256);
     if (!vocab_encode) {
         log_debug("Error: Failed to create hashmap for vocab_encode.");
-        PyErr_SetString(PyExc_MemoryError, "Failed to create hashmap for vocab_encode.");
+        PyErr_SetString(PyExc_MemoryError,
+                        "Failed to create hashmap for vocab_encode.");
         return NULL;
     }
 
-    FILE *file = fopen(vocab_file_path, "r");
+    FILE* file = fopen(vocab_file_path, "r");
     if (!file) {
         log_debug("Error: Could not open vocab file: %s", vocab_file_path);
         PyErr_SetString(PyExc_FileNotFoundError, "Could not open vocab file.");
         return NULL;
     }
 
-    log_debug("Successfully opened vocab file for encoding: %s", vocab_file_path);
+    log_debug("Successfully opened vocab file for encoding: %s",
+              vocab_file_path);
 
     char line[1024];
     while (fgets(line, sizeof(line), file)) {
-        char *hex_token = strtok(line, " == ");
-        char *value_str = strtok(NULL, " == ");
+        char* hex_token = strtok(line, " == ");
+        char* value_str = strtok(NULL, " == ");
         if (!hex_token || !value_str) {
             log_debug("Error: Invalid line format in vocab file: %s", line);
             continue;
@@ -89,14 +97,14 @@ static PyObject *p_initialize(PyObject *self, PyObject *args, PyObject *kwargs) 
 
         size_t hex_len = strlen(hex_token);
         size_t decoded_string_len = hex_len / 4 + 1;
-        char *decoded_string = malloc(decoded_string_len);
+        char* decoded_string = malloc(decoded_string_len);
         if (!decoded_string) {
             log_debug("Error: Memory allocation failed for decoded string.");
-            fclose(file);
+            (void)fclose(file);
             return PyErr_NoMemory();
         }
 
-        const char *pos = hex_token;
+        const char* pos = hex_token;
         size_t char_index = 0;
         while (pos[0] == '0' && pos[1] == 'x') {
             unsigned int byte_value;
@@ -110,39 +118,43 @@ static PyObject *p_initialize(PyObject *self, PyObject *args, PyObject *kwargs) 
         }
         decoded_string[char_index] = '\0';
 
-        char *key = strdup(decoded_string);
+        char* key = strdup(decoded_string);
         if (!key) {
             log_debug("Error: Memory allocation failed for key string.");
             free(decoded_string);
-            fclose(file);
+            (void)fclose(file);
             return PyErr_NoMemory();
         }
         int value = atoi(value_str);
 
         hashmap_set(vocab_encode, &(struct Token){.key = key, .value = value});
-        log_debug("Added vocab entry for encoding: key=%s, value=%d", key, value);
+        log_debug("Added vocab entry for encoding: key=%s, value=%d", key,
+                  value);
 
         free(decoded_string);
     }
 
-    fclose(file);
+    (void)fclose(file);
     initialized_encode = true;
     log_debug("Successfully initialized encoding.");
 
     // Initialize decoding
     file = fopen(vocab_file_path, "r");
     if (!file) {
-        log_debug("Error: Could not open vocab file for decoding: %s", vocab_file_path);
+        log_debug("Error: Could not open vocab file for decoding: %s",
+                  vocab_file_path);
         PyErr_SetString(PyExc_FileNotFoundError, "Could not open vocab file.");
         return NULL;
     }
 
-    log_debug("Successfully opened vocab file for decoding: %s", vocab_file_path);
+    log_debug("Successfully opened vocab file for decoding: %s",
+              vocab_file_path);
 
     // Count the number of lines in the file to determine vocab size
     vocab_size_decode = 0;
     while (fgets(line, sizeof(line), file)) {
-        if (strchr(line, '=') != NULL) { // Ensure the line contains a valid entry
+        if (strchr(line, '=') !=
+            NULL) {  // Ensure the line contains a valid entry
             vocab_size_decode++;
         }
     }
@@ -151,16 +163,18 @@ static PyObject *p_initialize(PyObject *self, PyObject *args, PyObject *kwargs) 
 
     if (vocab_size_decode == 0) {
         log_debug("Error: Vocab file is empty or contains no valid entries.");
-        PyErr_SetString(PyExc_ValueError, "Vocab file is empty or contains no valid entries.");
-        fclose(file);
+        PyErr_SetString(PyExc_ValueError,
+                        "Vocab file is empty or contains no valid entries.");
+        (void)fclose(file);
         return NULL;
     }
 
-    vocab_decode = malloc(vocab_size_decode * sizeof(char *));
+    vocab_decode = (char**)malloc(vocab_size_decode * sizeof(char*));
     if (!vocab_decode) {
         log_debug("Error: Memory allocation failed for vocab_decode array.");
-        PyErr_SetString(PyExc_MemoryError, "Memory allocation failed for vocab_decode array.");
-        fclose(file);
+        PyErr_SetString(PyExc_MemoryError,
+                        "Memory allocation failed for vocab_decode array.");
+        (void)fclose(file);
         return NULL;
     }
 
@@ -170,12 +184,13 @@ static PyObject *p_initialize(PyObject *self, PyObject *args, PyObject *kwargs) 
 
     rewind(file);
 
-    char *hex_str = malloc(1024);
+    char* hex_str = malloc(1024);
     if (!hex_str) {
         log_debug("Error: Memory allocation failed for hex_str.");
-        PyErr_SetString(PyExc_MemoryError, "Memory allocation failed for hex_str.");
-        fclose(file);
-        free(vocab_decode);
+        PyErr_SetString(PyExc_MemoryError,
+                        "Memory allocation failed for hex_str.");
+        (void)fclose(file);
+        free((void*)vocab_decode);
         return NULL;
     }
 
@@ -186,9 +201,9 @@ static PyObject *p_initialize(PyObject *self, PyObject *args, PyObject *kwargs) 
         if (sscanf(line, "%9999s == %d", hex_str, &value) != 2) {
             log_debug("Error: Invalid format in vocab file: %s", line);
             PyErr_SetString(PyExc_ValueError, "Invalid format in vocab file.");
-            fclose(file);
+            (void)fclose(file);
             free(hex_str);
-            free(vocab_decode);
+            free((void*)vocab_decode);
             return NULL;
         }
 
@@ -196,31 +211,37 @@ static PyObject *p_initialize(PyObject *self, PyObject *args, PyObject *kwargs) 
         hex_str_to_ascii(hex_str, ascii_str, sizeof(ascii_str));
 
         if (ascii_str[0] == '\0') {
-            log_debug("Error: Failed to convert hex string to ASCII: %s", hex_str);
-            PyErr_SetString(PyExc_RuntimeError, "Failed to convert hex string to ASCII.");
-            fclose(file);
+            log_debug("Error: Failed to convert hex string to ASCII: %s",
+                      hex_str);
+            PyErr_SetString(PyExc_RuntimeError,
+                            "Failed to convert hex string to ASCII.");
+            (void)fclose(file);
             free(hex_str);
-            free(vocab_decode);
+            free((void*)vocab_decode);
             return NULL;
         }
 
         vocab_decode[value] = strdup(ascii_str);
         if (!vocab_decode[value]) {
-            log_debug("Error: Memory allocation failed for vocab entry at index %d.", value);
-            PyErr_SetString(PyExc_MemoryError, "Memory allocation failed for vocab entry.");
-            fclose(file);
+            log_debug(
+                "Error: Memory allocation failed for vocab entry at index %d.",
+                value);
+            PyErr_SetString(PyExc_MemoryError,
+                            "Memory allocation failed for vocab entry.");
+            (void)fclose(file);
             free(hex_str);
-            free(vocab_decode);
+            free((void*)vocab_decode);
             return NULL;
         }
 
-        log_debug("Loaded vocab entry for decoding: index=%d, value=%s", value, ascii_str);
+        log_debug("Loaded vocab entry for decoding: index=%d, value=%s", value,
+                  ascii_str);
 
         index++;
     }
 
     free(hex_str);
-    fclose(file);
+    (void)fclose(file);
 
     initialized_decode = true;
     log_debug("Successfully initialized decoding.");
@@ -228,39 +249,34 @@ static PyObject *p_initialize(PyObject *self, PyObject *args, PyObject *kwargs) 
     Py_RETURN_NONE;
 }
 
-PyObject *p_encode(PyObject *self, PyObject *args)
-{
-
-    if (!initialized_encode)
-    {
-        PyErr_SetString(
-            PyExc_RuntimeError,
-            "Vocabulary is not initialized for encoding. "
-            "Call 'initialize_encode' function first."
-        );
+PyObject* p_encode(PyObject* self, PyObject* args) {
+    if (!initialized_encode) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "Vocabulary is not initialized for encoding. "
+                        "Call 'initialize_encode' function first.");
         return NULL;
     }
 
-    char *text;
+    char* text = NULL;
 
-    if (!PyArg_ParseTuple(args, "s", &text))
+    if (!PyArg_ParseTuple(args, "s", &text)) {
         return NULL;
+    }
 
     int tokens_size = 0;
     int tokens[strlen(text)];
 
     encode(text, vocab_encode, pattern, tokens, &tokens_size);
 
-    PyObject *list = PyList_New(tokens_size);
-    if (!list)
+    PyObject* list = PyList_New(tokens_size);
+    if (!list) {
         return PyErr_NoMemory();
+    }
 
-    for (int i = 0; i < tokens_size; i++)
-    {
-        PyObject *item = PyLong_FromLong(tokens[i]);
-        if (!item)
-        {
-            Py_DECREF(list); // cleanup in case of error
+    for (int i = 0; i < tokens_size; i++) {
+        PyObject* item = PyLong_FromLong(tokens[i]);
+        if (!item) {
+            Py_DECREF(list);  // cleanup in case of error
             return PyErr_NoMemory();
         }
         PyList_SetItem(list, i, item);
@@ -268,27 +284,27 @@ PyObject *p_encode(PyObject *self, PyObject *args)
     return list;
 }
 
-static PyObject *p_decode(PyObject *self, PyObject *args) {
+static PyObject* p_decode(PyObject* self, PyObject* args) {
     if (!initialized_decode) {
         PyErr_SetString(PyExc_RuntimeError,
-            "Vocabulary is not initialized for decoding. "
-            "Call 'initialize_decode' function first."
-        );
+                        "Vocabulary is not initialized for decoding. "
+                        "Call 'initialize_decode' function first.");
         return NULL;
     }
 
     if (!vocab_size_decode) {
         PyErr_SetString(PyExc_RuntimeError,
-            "Vocab size is not properly set during initialization. "
-            "Please try again."
-        );
+                        "Vocab size is not properly set during initialization. "
+                        "Please try again.");
         return NULL;
     }
 
-    PyObject *tokens;
+    PyObject* tokens = NULL;
 
     if (!PyArg_ParseTuple(args, "O", &tokens)) {
-        PyErr_SetString(PyExc_TypeError, "Failed to parse arguments. Expected a single list of tokens.");
+        PyErr_SetString(
+            PyExc_TypeError,
+            "Failed to parse arguments. Expected a single list of tokens.");
         return NULL;
     }
 
@@ -302,19 +318,15 @@ static PyObject *p_decode(PyObject *self, PyObject *args) {
 
 static PyMethodDef huTokenMethods[] = {
     {"bpe_train", p_bpe_train, METH_VARARGS, "BPE training"},
-    {"initialize", (PyCFunction)p_initialize, METH_VARARGS | METH_KEYWORDS, "Initalize tokenizer"},
+    {"initialize", (PyCFunction)p_initialize, METH_VARARGS | METH_KEYWORDS,
+     "Initalize tokenizer"},
     {"encode", p_encode, METH_VARARGS, "Encodes string"},
     {"decode", p_decode, METH_VARARGS, "Decodes list of ints"},
-    {NULL, NULL, 0, NULL} 
-};
+    {NULL, NULL, 0, NULL}};
 
-static struct PyModuleDef huToken = {
-    PyModuleDef_HEAD_INIT,
-    "huToken",
-    "hutoken module description",
-    -1,
-    huTokenMethods
-};
+static struct PyModuleDef huToken = {PyModuleDef_HEAD_INIT, "huToken",
+                                     "hutoken module description", -1,
+                                     huTokenMethods};
 
 PyMODINIT_FUNC PyInit__hutoken(void) {
     return PyModule_Create(&huToken);

--- a/src/lib.c
+++ b/src/lib.c
@@ -1,12 +1,14 @@
+#include "lib.h"
+
 #include <Python.h>
 
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include "bpe.c"
-#include "core.c"
-#include "helper.c"
+#include "bpe.h"
+#include "core.h"
+#include "helper.h"
 
 
 static bool initialized_encode = false;

--- a/src/lib.c
+++ b/src/lib.c
@@ -4,9 +4,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "helper.c"
-#include "core.c"
 #include "bpe.c"
+#include "core.c"
+#include "helper.c"
 
 
 static bool initialized_encode = false;

--- a/src/lib.c
+++ b/src/lib.c
@@ -1,4 +1,4 @@
-#include "lib.h"
+#include "hutoken/lib.h"
 
 #include <Python.h>
 
@@ -6,9 +6,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "bpe.h"
-#include "core.h"
-#include "helper.h"
+#include "hutoken/bpe.h"
+#include "hutoken/core.h"
+#include "hutoken/helper.h"
 
 
 static bool initialized_encode = false;


### PR DESCRIPTION
Integration of `clang-format` and `clang-tidy` with the following configurations:

- `clang-format`: Google's Chromium configuration.
- `clang-tidy`: Recommended CPP configuration, with more excluded lints which are not relevant to C.

Alongside this, the following has been implemented:

- Header files for every source file, with updated `setup.py` for the new compilation pipeline.
- `compile_flags.txt` file for LSP integration in modern IDEs.
- Fixes for clang-tidy lints.

    > Note: Only trivial fixes have been implemented. Some warning lints still remain, which would require bigger changes. For example, use-after-free errors and memory leaks are diagnosed by clang-tidy, however, these will be fixed in another pull request.

- Formatting has been applied to the whole library code.