### PR TITLE
`transformers` compatibility

### DIFF
--- a/hutoken.py
+++ b/hutoken.py
@@ -8,6 +8,14 @@ try:
 except ImportError:
     _hutoken = None
 
+# the characters which GPT2Tokenizer encodes differently.
+_SPECIAL_CHARS = [
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+    21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 127, 128, 129, 130, 131,
+    132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146,
+    147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 173
+]
+
 def initialize(model_or_path, *args, **kwargs):
     """
     Initialize hutoken with either a vocab file path or a Hugging Face model name.
@@ -52,6 +60,18 @@ def initialize(model_or_path, *args, **kwargs):
         except IOError as e:
             traceback.print_exc(file=sys.stderr)
             raise IOError(f"Could not write vocab file to '{vocab_file}': {e}")
+
+        special_chars_file = os.path.join(vocab_dir, f"{model_name}_special_chars.txt")
+
+        try:
+            with open(special_chars_file, "w", encoding="utf-8") as f:
+                for char in _SPECIAL_CHARS:
+                    value = ''.join(hf_tokenizer.tokenize(chr(char)))
+                    f.write(f"{char} == {value}\n")
+        except IOError as e:
+            traceback.print_exc(file=sys.stderr)
+            raise IOError("Could not write special characters file to "
+                          f"'{special_chars_file}': {e}")
 
         try:
             result = _hutoken.initialize(vocab_file, *args, **kwargs)

--- a/hutoken.py
+++ b/hutoken.py
@@ -28,9 +28,10 @@ def initialize(model_or_path, *args, **kwargs):
             raise ValueError(f"Special characters file '{special_chars_file}' does not exist.")
         
         prefix = kwargs.get('prefix', None)
+        is_byte_encoder = kwargs.get('is_byte_encoder', False)
         token_id = kwargs.get('token_id', -1)
 
-        result = _hutoken.initialize(model_or_path, special_chars_file, prefix, token_id)
+        result = _hutoken.initialize(model_or_path, special_chars_file, prefix, is_byte_encoder, token_id)
         return result
     else:
         try:
@@ -71,7 +72,7 @@ def initialize(model_or_path, *args, **kwargs):
         hu_tokenized = hf_tokenizer.tokenize("hu")[0]
         prefix = hu_tokenized[0] if hu_tokenized != "hu" else None
 
-        hf_tokenizer = AutoTokenizer.from_pretrained(model_or_path, add_prefix_space=False)
+        hf_tokenizer = AutoTokenizer.from_pretrained(model_or_path, add_prefix_space=False, use_fast=False)
         special_chars_file = os.path.join(vocab_dir, f"{model_name}_special_chars.txt")
 
         try:
@@ -85,9 +86,13 @@ def initialize(model_or_path, *args, **kwargs):
             traceback.print_exc(file=sys.stderr)
             raise IOError("Could not write special characters file to "
                           f"'{special_chars_file}': {e}")
+            
+        is_byte_encoder = 0
+        if hasattr(hf_tokenizer, 'byte_encoder') and hf_tokenizer.byte_encoder is not None:
+            is_byte_encoder = 1
 
         try:
-            result = _hutoken.initialize(vocab_file, special_chars_file, prefix, *args, **kwargs)
+            result = _hutoken.initialize(vocab_file, special_chars_file, prefix, is_byte_encoder, *args, **kwargs)
         except Exception as e:
             traceback.print_exc(file=sys.stderr)
             raise RuntimeError("An unexpected error occured during "

--- a/hutoken.py
+++ b/hutoken.py
@@ -68,6 +68,8 @@ def initialize(model_or_path, *args, **kwargs):
             with open(special_chars_file, "w", encoding="utf-8") as f:
                 for char in _SPECIAL_CHARS:
                     value = ''.join(hf_tokenizer.tokenize(chr(char)))
+                    if (value == char):
+                        continue
                     f.write(f"{char} == {value}\n")
         except IOError as e:
             traceback.print_exc(file=sys.stderr)

--- a/hutoken.py
+++ b/hutoken.py
@@ -74,7 +74,7 @@ def initialize(model_or_path, *args, **kwargs):
                           f"'{special_chars_file}': {e}")
 
         try:
-            result = _hutoken.initialize(vocab_file, *args, **kwargs)
+            result = _hutoken.initialize(vocab_file, special_chars_file, *args, **kwargs)
         except Exception as e:
             traceback.print_exc(file=sys.stderr)
             raise RuntimeError("An unexpected error occured during "

--- a/hutoken.py
+++ b/hutoken.py
@@ -27,7 +27,8 @@ def initialize(model_or_path, *args, **kwargs):
         return result
     else:
         try:
-            hf_tokenizer = AutoTokenizer.from_pretrained(model_or_path)
+            hf_tokenizer = AutoTokenizer.from_pretrained(model_or_path,
+                                                         add_prefix_space=False)
         except OSError as e:
             raise ValueError("Could not download Hugging Face tokenizer "
                              f"'{model_or_path}': {e}")

--- a/hutoken.py
+++ b/hutoken.py
@@ -72,7 +72,7 @@ def initialize(model_or_path, *args, **kwargs):
         hu_tokenized = hf_tokenizer.tokenize("hu")[0]
         prefix = hu_tokenized[0] if hu_tokenized != "hu" else None
 
-        hf_tokenizer = AutoTokenizer.from_pretrained(model_or_path, add_prefix_space=False, use_fast=True if prefix is not None else None)
+        hf_tokenizer = AutoTokenizer.from_pretrained(model_or_path, use_fast=False, add_prefix_space=False if prefix is not None else None)
         special_chars_file = os.path.join(vocab_dir, f"{model_name}_special_chars.txt")
 
         try:

--- a/hutoken.py
+++ b/hutoken.py
@@ -111,6 +111,9 @@ def decode(tokens):
     try:
         text = _hutoken.decode(tokens)
         return text
+    except ValueError as e:
+        traceback.print_exc(file=sys.stderr)
+        raise ValueError(f"hutoken: Error decoding tokens {tokens}: {e}")
     except Exception as e:
         traceback.print_exc(file=sys.stderr)
         raise RuntimeError(f"hutoken: Error decoding tokens: {e}")

--- a/hutoken.py
+++ b/hutoken.py
@@ -27,8 +27,7 @@ def initialize(model_or_path, *args, **kwargs):
         return result
     else:
         try:
-            hf_tokenizer = AutoTokenizer.from_pretrained(model_or_path,
-                                                         add_prefix_space=False)
+            hf_tokenizer = AutoTokenizer.from_pretrained(model_or_path)
         except OSError as e:
             raise ValueError("Could not download Hugging Face tokenizer "
                              f"'{model_or_path}': {e}")
@@ -62,6 +61,11 @@ def initialize(model_or_path, *args, **kwargs):
             traceback.print_exc(file=sys.stderr)
             raise IOError(f"Could not write vocab file to '{vocab_file}': {e}")
 
+        hu_tokenized = hf_tokenizer.tokenize("hu")[0]
+        prefix = hu_tokenized[0] if hu_tokenized != "hu" else None
+        print(prefix)
+
+        hf_tokenizer = AutoTokenizer.from_pretrained(model_or_path, add_prefix_space=False)
         special_chars_file = os.path.join(vocab_dir, f"{model_name}_special_chars.txt")
 
         try:
@@ -77,7 +81,7 @@ def initialize(model_or_path, *args, **kwargs):
                           f"'{special_chars_file}': {e}")
 
         try:
-            result = _hutoken.initialize(vocab_file, special_chars_file, *args, **kwargs)
+            result = _hutoken.initialize(vocab_file, special_chars_file, prefix, *args, **kwargs)
         except Exception as e:
             traceback.print_exc(file=sys.stderr)
             raise RuntimeError("An unexpected error occured during "

--- a/hutoken.py
+++ b/hutoken.py
@@ -63,7 +63,6 @@ def initialize(model_or_path, *args, **kwargs):
 
         hu_tokenized = hf_tokenizer.tokenize("hu")[0]
         prefix = hu_tokenized[0] if hu_tokenized != "hu" else None
-        print(prefix)
 
         hf_tokenizer = AutoTokenizer.from_pretrained(model_or_path, add_prefix_space=False)
         special_chars_file = os.path.join(vocab_dir, f"{model_name}_special_chars.txt")

--- a/hutoken.py
+++ b/hutoken.py
@@ -72,7 +72,7 @@ def initialize(model_or_path, *args, **kwargs):
         hu_tokenized = hf_tokenizer.tokenize("hu")[0]
         prefix = hu_tokenized[0] if hu_tokenized != "hu" else None
 
-        hf_tokenizer = AutoTokenizer.from_pretrained(model_or_path, add_prefix_space=False, use_fast=False)
+        hf_tokenizer = AutoTokenizer.from_pretrained(model_or_path, add_prefix_space=False, use_fast=True if prefix is not None else None)
         special_chars_file = os.path.join(vocab_dir, f"{model_name}_special_chars.txt")
 
         try:

--- a/hutoken.py
+++ b/hutoken.py
@@ -26,7 +26,7 @@ def initialize(model_or_path, *args, **kwargs):
         special_chars_file = args[0] if args else None
         if special_chars_file and not os.path.isfile(special_chars_file):
             raise ValueError(f"Special characters file '{special_chars_file}' does not exist.")
-        
+
         prefix = kwargs.get('prefix', None)
         is_byte_encoder = kwargs.get('is_byte_encoder', False)
         token_id = kwargs.get('token_id', -1)
@@ -89,8 +89,8 @@ def initialize(model_or_path, *args, **kwargs):
             traceback.print_exc(file=sys.stderr)
             raise IOError("Could not write special characters file to "
                           f"'{special_chars_file}': {e}")
-            
-        is_byte_encoder = 0
+
+        is_byte_encoder = kwargs.get("is_byte_encoder", 0)
         if hasattr(hf_tokenizer, 'byte_encoder') and hf_tokenizer.byte_encoder is not None:
             is_byte_encoder = 1
 

--- a/hutoken.py
+++ b/hutoken.py
@@ -23,7 +23,14 @@ def initialize(model_or_path, *args, **kwargs):
     if os.path.isfile(model_or_path):
         if _hutoken is None:
             raise RuntimeError("hutoken: Native C extension '_hutoken' is not installed or failed to import.")
-        result = _hutoken.initialize(model_or_path, *args, **kwargs)
+        special_chars_file = args[0] if args else None
+        if special_chars_file and not os.path.isfile(special_chars_file):
+            raise ValueError(f"Special characters file '{special_chars_file}' does not exist.")
+        
+        prefix = kwargs.get('prefix', None)
+        token_id = kwargs.get('token_id', -1)
+
+        result = _hutoken.initialize(model_or_path, special_chars_file, prefix, token_id)
         return result
     else:
         try:

--- a/hutoken.py
+++ b/hutoken.py
@@ -78,7 +78,10 @@ def initialize(model_or_path, *args, **kwargs):
         try:
             with open(special_chars_file, "w", encoding="utf-8") as f:
                 for char in _SPECIAL_CHARS:
-                    value = ''.join(hf_tokenizer.tokenize(chr(char)))
+                    if hasattr(hf_tokenizer, "byte_encoder"):
+                        value = hf_tokenizer.byte_encoder[char]
+                    else:
+                        value = ''.join(hf_tokenizer.tokenize(chr(char)))
                     if (value == char):
                         continue
                     f.write(f"{char} == {value}\n")

--- a/include/hutoken/core.h
+++ b/include/hutoken/core.h
@@ -14,7 +14,7 @@ void encode(char* text,
             const char **special_chars,
             const char *prefix,
             bool is_byte_encoder);
-PyObject* decode(PyObject* tokens, char** vocab_decode, int vocab_size, const char **special_chars, const char *prefix);
+PyObject* decode(PyObject* tokens, char** vocab_decode, int vocab_size, const char **special_chars, const char *prefix, bool is_byte_encoder);
 PyObject* initialize_foma(void);
 PyObject* look_up_word(struct apply_handle* handle,
                        char* word,

--- a/include/hutoken/core.h
+++ b/include/hutoken/core.h
@@ -12,7 +12,8 @@ void encode(char* text,
             int tokens[],
             int* tokens_size,
             const char **special_chars,
-            const char *prefix);
+            const char *prefix,
+            bool is_byte_encoder);
 PyObject* decode(PyObject* tokens, char** vocab_decode, int vocab_size, const char **special_chars, const char *prefix);
 PyObject* initialize_foma(void);
 PyObject* look_up_word(struct apply_handle* handle,

--- a/include/hutoken/core.h
+++ b/include/hutoken/core.h
@@ -10,8 +10,10 @@ void encode(char* text,
             struct HashMap* vocab,
             char* pattern,
             int tokens[],
-            int* tokens_size);
-PyObject* decode(PyObject* tokens, char** vocab_decode, int vocab_size);
+            int* tokens_size,
+            const char **special_chars,
+            const char *prefix);
+PyObject* decode(PyObject* tokens, char** vocab_decode, int vocab_size, const char **special_chars, const char *prefix);
 PyObject* initialize_foma(void);
 PyObject* look_up_word(struct apply_handle* handle,
                        char* word,

--- a/include/hutoken/core.h
+++ b/include/hutoken/core.h
@@ -11,10 +11,15 @@ void encode(char* text,
             char* pattern,
             int tokens[],
             int* tokens_size,
-            const char **special_chars,
-            const char *prefix,
+            const char** special_chars,
+            const char* prefix,
             bool is_byte_encoder);
-PyObject* decode(PyObject* tokens, char** vocab_decode, int vocab_size, const char **special_chars, const char *prefix, bool is_byte_encoder);
+PyObject* decode(PyObject* tokens,
+                 char** vocab_decode,
+                 int vocab_size,
+                 const char** special_chars,
+                 const char* prefix,
+                 bool is_byte_encoder);
 PyObject* initialize_foma(void);
 PyObject* look_up_word(struct apply_handle* handle,
                        char* word,

--- a/include/hutoken/pretokenizer.h
+++ b/include/hutoken/pretokenizer.h
@@ -1,12 +1,14 @@
 #ifndef HUTOKEN_PRETOKENIZER_H
 #define HUTOKEN_PRETOKENIZER_H
 
-int utf8_char_length(char c);
+#include <stdbool.h>
+
+int utf8_char_length(const unsigned char* c);
 
 char* pretokenizer_encode(const char* text,
                           const char** special_chars,
                           const char* prefix,
-                          char** is_special_out);
+                          bool is_byte_encoder);
 char* pretokenizer_decode(const char* text,
                           const char** special_chars,
                           const char* prefix);

--- a/include/hutoken/pretokenizer.h
+++ b/include/hutoken/pretokenizer.h
@@ -11,6 +11,7 @@ char* pretokenizer_encode(const char* text,
                           bool is_byte_encoder);
 char* pretokenizer_decode(const char* text,
                           const char** special_chars,
-                          const char* prefix);
+                          const char* prefix,
+                          bool byte_level);
 
 #endif

--- a/include/hutoken/pretokenizer.h
+++ b/include/hutoken/pretokenizer.h
@@ -1,7 +1,9 @@
 #ifndef HUTOKEN_PRETOKENIZER_H
 #define HUTOKEN_PRETOKENIZER_H
 
-char* pretokenizer_encode(const char* text, const char** special_chars);
+char* pretokenizer_encode(const char* text,
+                          const char** special_chars,
+                          const char* prefix);
 char* pretokenizer_decode(const char* text, const char** special_chars);
 
 #endif

--- a/include/hutoken/pretokenizer.h
+++ b/include/hutoken/pretokenizer.h
@@ -4,6 +4,7 @@
 char* pretokenizer_encode(const char* text,
                           const char** special_chars,
                           const char* prefix);
-char* pretokenizer_decode(const char* text, const char** special_chars);
+char* pretokenizer_decode(const char* text, const char** special_chars, 
+                          const char* prefix);
 
 #endif

--- a/include/hutoken/pretokenizer.h
+++ b/include/hutoken/pretokenizer.h
@@ -4,7 +4,8 @@
 char* pretokenizer_encode(const char* text,
                           const char** special_chars,
                           const char* prefix);
-char* pretokenizer_decode(const char* text, const char** special_chars, 
+char* pretokenizer_decode(const char* text,
+                          const char** special_chars,
                           const char* prefix);
 
 #endif

--- a/include/hutoken/pretokenizer.h
+++ b/include/hutoken/pretokenizer.h
@@ -1,0 +1,7 @@
+#ifndef HUTOKEN_PRETOKENIZER_H
+#define HUTOKEN_PRETOKENIZER_H
+
+char* pretokenizer_encode(const char* text, const char** special_chars);
+char* pretokenizer_decode(const char* text, const char** special_chars);
+
+#endif

--- a/include/hutoken/pretokenizer.h
+++ b/include/hutoken/pretokenizer.h
@@ -1,9 +1,12 @@
 #ifndef HUTOKEN_PRETOKENIZER_H
 #define HUTOKEN_PRETOKENIZER_H
 
+int utf8_char_length(char c);
+
 char* pretokenizer_encode(const char* text,
                           const char** special_chars,
-                          const char* prefix);
+                          const char* prefix,
+                          char** is_special_out);
 char* pretokenizer_decode(const char* text,
                           const char** special_chars,
                           const char* prefix);

--- a/include/hutoken/string.h
+++ b/include/hutoken/string.h
@@ -31,6 +31,9 @@ void string_release(struct String* str);
 const char* string_c_str(const struct String* str);
 size_t string_len(const struct String* str);
 enum StringError string_append(struct String* str, const char* to_append);
+enum StringError string_append_n(struct String* str,
+                                 const char* to_append,
+                                 size_t n);
 enum StringError string_clear(struct String* str);
 
 #endif

--- a/include/hutoken/string.h
+++ b/include/hutoken/string.h
@@ -31,5 +31,6 @@ void string_release(struct String* str);
 const char* string_c_str(const struct String* str);
 size_t string_len(const struct String* str);
 enum StringError string_append(struct String* str, const char* to_append);
+enum StringError string_clear(struct String* str);
 
 #endif

--- a/include/hutoken/string.h
+++ b/include/hutoken/string.h
@@ -1,0 +1,35 @@
+#ifndef HUTOKEN_STRING_H
+#define HUTOKEN_STRING_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#define STRING_SSO_MAX_LEN (sizeof(((struct String*)0)->data.small) - 1)
+
+struct String {
+    bool is_large;
+    union {
+        struct LargeString {
+            size_t len;
+            size_t capacity;
+            char* buf;
+        } large;
+        char small[sizeof(struct LargeString) - 1];
+    } data;
+};
+
+enum StringError {
+    STRING_SUCCESS,
+    STRING_ALLOC_ERROR,
+    STRING_INVALID_ARGUMENT,
+};
+
+enum StringError string_init(struct String* str, const char* init);
+enum StringError string_with_capacity(struct String* str, size_t capacity);
+void string_release(struct String* str);
+
+const char* string_c_str(const struct String* str);
+size_t string_len(const struct String* str);
+enum StringError string_append(struct String* str, const char* to_append);
+
+#endif

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     ext_modules=[
         Extension(
             "_hutoken",
-            ["src/lib.c", "src/bpe.c", "src/core.c", "src/hash.c", "src/hashmap.c", "src/helper.c"],
+            ["src/lib.c", "src/bpe.c", "src/core.c", "src/hash.c", "src/hashmap.c", "src/helper.c", "src/string.c"],
             extra_compile_args=["-O3", "-march=native", "-funroll-loops", "-Iinclude"],
             extra_link_args=["-flto", "-lfoma"]
         )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     ext_modules=[
         Extension(
             "_hutoken",
-            ["src/lib.c", "src/bpe.c", "src/core.c", "src/hash.c", "src/hashmap.c", "src/helper.c", "src/string.c"],
+            ["src/lib.c", "src/bpe.c", "src/core.c", "src/hash.c", "src/hashmap.c", "src/helper.c", "src/string.c", "src/pretokenizer.c"],
             extra_compile_args=["-O3", "-march=native", "-funroll-loops", "-Iinclude"],
             extra_link_args=["-flto", "-lfoma"]
         )

--- a/src/core.c
+++ b/src/core.c
@@ -134,7 +134,7 @@ void encode(char* text,
         struct Boundary word_token_boundaries[word_len];
 
         for (char* ptr = encoded_word; *ptr != '\0';
-            ptr += utf8_char_length((unsigned char*)ptr)) {
+             ptr += utf8_char_length((unsigned char*)ptr)) {
             int char_len = utf8_char_length((unsigned char*)ptr);
             char* start = ptr;
             char* end = ptr + char_len - 1;

--- a/src/core.c
+++ b/src/core.c
@@ -84,15 +84,13 @@ void bpe_encode(struct HashMap* vocab,
     }
 }
 
-
-
 void encode(char* text,
             struct HashMap* vocab,
             char* pattern,
             int tokens[],
             int* tokens_size,
-            const char **special_chars,
-            const char *prefix) {
+            const char** special_chars,
+            const char* prefix) {
     log_debug("Starting encode function with text: %s", text);
 
     regex_t regex;
@@ -122,36 +120,35 @@ void encode(char* text,
             continue;
         }
 
-        char *word = malloc(word_len + 1);
-        char *is_special = NULL;
+        char* word = malloc(word_len + 1);
+        char* is_special = NULL;
         memcpy(word, cursor, word_len);
         word[word_len] = '\0';
-        log_debug("Matched word: start=%d, end=%d, length=%d, word='%s'", word_start,
-                  word_end, word_len, word);
-        char *encoded_word = pretokenizer_encode(word, special_chars, add_prefix ? prefix : NULL, &is_special);
+        log_debug("Matched word: start=%d, end=%d, length=%d, word='%s'",
+                  word_start, word_end, word_len, word);
+        char* encoded_word = pretokenizer_encode(
+            word, special_chars, add_prefix ? prefix : NULL, &is_special);
         log_debug("encoded_word='%s'", encoded_word);
         add_prefix = false;
 
         int i = 0;
         struct Boundary word_token_boundaries[word_len];
 
-        for (char* ptr = encoded_word; *ptr != '\0'; ptr+= utf8_char_length(*ptr)) {
+        for (char* ptr = encoded_word; *ptr != '\0';
+             ptr += utf8_char_length(*ptr)) {
             int char_len = utf8_char_length(*ptr);
             char* start = ptr;
             char* end = ptr + char_len - 1;
 
             struct Boundary word_token_boundary = {.start = start, .end = end};
 
-            if (!is_special[i] && char_len > 1){
+            if (!is_special[i] && char_len > 1) {
                 for (int j = 0; j < char_len - 1; j++) {
-                    struct Boundary sub_boundary = {
-                        .start = ptr + j,
-                        .end = ptr + j
-                    };
+                    struct Boundary sub_boundary = {.start = ptr + j,
+                                                    .end = ptr + j};
                     word_token_boundaries[i++] = sub_boundary;
                 }
-            }
-            else{
+            } else {
                 word_token_boundaries[i++] = word_token_boundary;
             }
 
@@ -174,7 +171,11 @@ void encode(char* text,
     log_debug("Completed encode function. Total tokens: %d", *tokens_size);
 }
 
-PyObject* decode(PyObject* tokens, char** vocab_decode, int vocab_size, const char **special_chars, const char *prefix) {
+PyObject* decode(PyObject* tokens,
+                 char** vocab_decode,
+                 int vocab_size,
+                 const char** special_chars,
+                 const char* prefix) {
     log_debug("Entered decode function");
 
     Py_ssize_t token_num = PyList_Size(tokens);
@@ -250,7 +251,7 @@ PyObject* decode(PyObject* tokens, char** vocab_decode, int vocab_size, const ch
             word, text, text_size);
     }
 
-    char *decoded_text = pretokenizer_decode(text, special_chars, prefix);
+    char* decoded_text = pretokenizer_decode(text, special_chars, prefix);
 
     PyObject* result = PyUnicode_FromString(decoded_text);
     if (!result) {

--- a/src/core.c
+++ b/src/core.c
@@ -158,6 +158,8 @@ void encode(char* text,
         int word_token_num = i;
         int word_tokens[word_len];
 
+        bpe_encode(vocab, word_token_boundaries, word_tokens, &word_token_num);
+
         for (int i = 0; i < word_token_num; i++) {
             tokens[i + *tokens_size] = word_tokens[i];
             log_debug("Encoded token: %d", word_tokens[i]);

--- a/src/core.c
+++ b/src/core.c
@@ -245,7 +245,8 @@ PyObject* decode(PyObject* tokens,
             word, text, text_size);
     }
 
-    char* decoded_text = pretokenizer_decode(text, special_chars, prefix, is_byte_encoder);
+    char* decoded_text =
+        pretokenizer_decode(text, special_chars, prefix, is_byte_encoder);
 
     PyObject* result = PyUnicode_FromString(decoded_text);
     if (!result) {

--- a/src/core.c
+++ b/src/core.c
@@ -168,7 +168,8 @@ PyObject* decode(PyObject* tokens,
                  char** vocab_decode,
                  int vocab_size,
                  const char** special_chars,
-                 const char* prefix) {
+                 const char* prefix,
+                 bool is_byte_encoder) {
     log_debug("Entered decode function");
 
     Py_ssize_t token_num = PyList_Size(tokens);
@@ -244,7 +245,7 @@ PyObject* decode(PyObject* tokens,
             word, text, text_size);
     }
 
-    char* decoded_text = pretokenizer_decode(text, special_chars, prefix);
+    char* decoded_text = pretokenizer_decode(text, special_chars, prefix, is_byte_encoder);
 
     PyObject* result = PyUnicode_FromString(decoded_text);
     if (!result) {

--- a/src/core.c
+++ b/src/core.c
@@ -127,7 +127,6 @@ void encode(char* text,
                   word_start, word_end, word_len, word);
         char* encoded_word = pretokenizer_encode(
             word, special_chars, add_prefix ? prefix : NULL, is_byte_encoder);
-        log_debug("encoded_word='%s'\n", encoded_word);
         add_prefix = false;
 
         int i = 0;
@@ -255,8 +254,10 @@ PyObject* decode(PyObject* tokens,
         return NULL;
     }
 
-    log_debug("Successfully created Python string from decoded text: '%s'",
-              decoded_text);
+    log_debug(
+        "Successfully created Python string from decoded text (UTF-8 encoded, "
+        "might be wrong here): '%s'",
+        decoded_text);
 
     free(text);
     free(decoded_text);

--- a/src/helper.c
+++ b/src/helper.c
@@ -76,7 +76,8 @@ void hex_str_to_ascii(const char* hex_str,
 
             if (hex_str[0] != '\0' && hex_str[1] != '\0') {
                 char hex_value[3] = {hex_str[0], hex_str[1], '\0'};
-                unsigned int byte_value = (unsigned int)strtol(hex_value, NULL, 16);
+                unsigned int byte_value =
+                    (unsigned int)strtol(hex_value, NULL, 16);
 
                 log_debug(
                     "Parsed hex value: %s -> ASCII char: %c (decimal: %d)",

--- a/src/helper.c
+++ b/src/helper.c
@@ -75,12 +75,12 @@ void hex_str_to_ascii(const char* hex_str,
             hex_str += 2;
 
             if (hex_str[0] != '\0' && hex_str[1] != '\0') {
-                char hexValue[3] = {hex_str[0], hex_str[1], '\0'};
-                int charValue = (int)strtol(hexValue, NULL, 16);
+                char hex_value[3] = {hex_str[0], hex_str[1], '\0'};
+                unsigned int byte_value = (unsigned int)strtol(hex_value, NULL, 16);
 
                 log_debug(
                     "Parsed hex value: %s -> ASCII char: %c (decimal: %d)",
-                    hexValue, (char)charValue, charValue);
+                    hex_value, (char)byte_value, byte_value);
 
                 if (i >= ascii_str_size - 1) {
                     log_debug(
@@ -94,7 +94,7 @@ void hex_str_to_ascii(const char* hex_str,
                     return;
                 }
 
-                ascii_str[i++] = (char)charValue;
+                ascii_str[i++] = (char)byte_value;
             } else {
                 log_debug("Error: Incomplete hex pair at position: %s",
                           hex_str);

--- a/src/lib.c
+++ b/src/lib.c
@@ -396,7 +396,8 @@ PyObject* p_encode(PyObject* self, PyObject* args) {
     int tokens[strlen(text)];
 
     log_debug("p_encode prefix='%s'", prefix);
-    encode(text, vocab_encode, pattern, tokens, &tokens_size, (const char**)special_chars, prefix);
+    encode(text, vocab_encode, pattern, tokens, &tokens_size,
+           (const char**)special_chars, prefix);
 
     PyObject* list = PyList_New(tokens_size);
     if (!list) {
@@ -443,7 +444,8 @@ static PyObject* p_decode(PyObject* self, PyObject* args) {
         return NULL;
     }
 
-    return decode(tokens, vocab_decode, vocab_size_decode, (const char **)special_chars, prefix);
+    return decode(tokens, vocab_decode, vocab_size_decode,
+                  (const char**)special_chars, prefix);
 }
 
 PyObject* p_initialize_foma(PyObject* self) {

--- a/src/lib.c
+++ b/src/lib.c
@@ -246,16 +246,12 @@ static PyObject* p_initialize(PyObject* self,
     while (fgets(line, sizeof(line), file)) {
         char* separator = strstr(line, " == ");
         if (separator == NULL) {
-            if (strchr(line, '=') != NULL) {
-                log_debug("Error: Invalid format in vocab file: %s", line);
-                PyErr_SetString(PyExc_ValueError,
-                                "Invalid format in vocab file.");
-                (void)fclose(file);
-                free(hex_str);
-                free((void*)vocab_decode);
-                return NULL;
-            }
-            continue;
+            log_debug("Error: Invalid format in vocab file: %s", line);
+            PyErr_SetString(PyExc_ValueError, "Invalid format in vocab file.");
+            (void)fclose(file);
+            free(hex_str);
+            free((void*)vocab_decode);
+            return NULL;
         }
 
         ptrdiff_t hex_len = separator - line;

--- a/src/lib.c
+++ b/src/lib.c
@@ -73,7 +73,8 @@ static PyObject* p_initialize(PyObject* self,
         log_debug("Error: Invalid arguments passed to initialize.");
         PyErr_SetString(
             PyExc_TypeError,
-            "Invalid arguments. Expected a string (vocab_file_path) and an "
+            "Invalid arguments. Expected a string (vocab_file_path), a string (special_file_path), "
+            "a string or None (prefix) and an "
             "optional integer (special_token_id).");
         return NULL;
     }

--- a/src/lib.c
+++ b/src/lib.c
@@ -68,6 +68,7 @@ static PyObject* p_initialize(PyObject* self,
     char* local_prefix = NULL;
     int local_is_byte_encoder = 0;
     int special_token_id = -1;  // Optional parameter for special token ID
+    prefix = NULL;
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "sszp|i", kwlist,
                                      &vocab_file_path, &special_file_path,

--- a/src/lib.c
+++ b/src/lib.c
@@ -453,7 +453,7 @@ static PyObject* p_decode(PyObject* self, PyObject* args) {
     }
 
     return decode(tokens, vocab_decode, vocab_size_decode,
-                  (const char**)special_chars, prefix);
+                  (const char**)special_chars, prefix, is_byte_encoder);
 }
 
 PyObject* p_initialize_foma(PyObject* self) {

--- a/src/lib.c
+++ b/src/lib.c
@@ -57,12 +57,15 @@ PyObject* p_bpe_train(PyObject* self, PyObject* args) {
 static PyObject* p_initialize(PyObject* self,
                               PyObject* args,
                               PyObject* kwargs) {
-    static char* kwlist[] = {"vocab_file_path", "special_token_id", NULL};
+    static char* kwlist[] = {"vocab_file_path", "special_file_path",
+                             "special_token_id", NULL};
     char* vocab_file_path = NULL;
+    char* special_file_path = NULL;
     int special_token_id = -1;  // Optional parameter for special token ID
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s|i", kwlist,
-                                     &vocab_file_path, &special_token_id)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "ss|i", kwlist,
+                                     &vocab_file_path, &special_file_path,
+                                     &special_token_id)) {
         log_debug("Error: Invalid arguments passed to initialize.");
         PyErr_SetString(
             PyExc_TypeError,

--- a/src/lib.c
+++ b/src/lib.c
@@ -28,6 +28,7 @@ struct HashMap* vocab_encode;
 char** vocab_decode;
 int vocab_size_decode;
 char* special_chars[256];
+char* prefix;
 #define MAX_LINE_LENGTH 10000
 
 PyObject* p_bpe_train(PyObject* self, PyObject* args) {
@@ -59,15 +60,15 @@ PyObject* p_bpe_train(PyObject* self, PyObject* args) {
 static PyObject* p_initialize(PyObject* self,
                               PyObject* args,
                               PyObject* kwargs) {
-    static char* kwlist[] = {"vocab_file_path", "special_file_path",
+    static char* kwlist[] = {"vocab_file_path", "special_file_path", "prefix",
                              "special_token_id", NULL};
     char* vocab_file_path = NULL;
     char* special_file_path = NULL;
     int special_token_id = -1;  // Optional parameter for special token ID
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "ss|i", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "ss|si", kwlist,
                                      &vocab_file_path, &special_file_path,
-                                     &special_token_id)) {
+                                     &prefix, &special_token_id)) {
         log_debug("Error: Invalid arguments passed to initialize.");
         PyErr_SetString(
             PyExc_TypeError,

--- a/src/lib.c
+++ b/src/lib.c
@@ -61,8 +61,8 @@ PyObject* p_bpe_train(PyObject* self, PyObject* args) {
 static PyObject* p_initialize(PyObject* self,
                               PyObject* args,
                               PyObject* kwargs) {
-    static char* kwlist[] = {"vocab_file_path", "special_file_path", "prefix", "is_byte_encoder",
-                             "special_token_id", NULL};
+    static char* kwlist[] = {"vocab_file_path", "special_file_path", "prefix",
+                             "is_byte_encoder", "special_token_id",  NULL};
     char* vocab_file_path = NULL;
     char* special_file_path = NULL;
     char* local_prefix = NULL;
@@ -71,13 +71,14 @@ static PyObject* p_initialize(PyObject* self,
 
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "sszp|i", kwlist,
                                      &vocab_file_path, &special_file_path,
-                                     &local_prefix, &local_is_byte_encoder, &special_token_id)) {
+                                     &local_prefix, &local_is_byte_encoder,
+                                     &special_token_id)) {
         log_debug("Error: Invalid arguments passed to initialize.");
-        PyErr_SetString(
-            PyExc_TypeError,
-            "Invalid arguments. Expected a string (vocab_file_path), a string (special_file_path), "
-            "a string or None (prefix) a bool and an"
-            "optional integer (special_token_id).");
+        PyErr_SetString(PyExc_TypeError,
+                        "Invalid arguments. Expected a string "
+                        "(vocab_file_path), a string (special_file_path), "
+                        "a string or None (prefix) a bool and an"
+                        "optional integer (special_token_id).");
         return NULL;
     }
 

--- a/src/lib.c
+++ b/src/lib.c
@@ -355,9 +355,7 @@ static PyObject* p_initialize(PyObject* self,
         }
 
         char* value_str = separator + 4;  // strlen(" == "), again
-        log_debug("value_str=%s", value_str);
         size_t value_len = strlen(value_str);
-        log_debug("value_len=%d", value_len);
         char* value = malloc(value_len);
         memcpy(value, value_str, value_len - 1);
         value[value_len - 1] = '\0';
@@ -403,7 +401,6 @@ PyObject* p_encode(PyObject* self, PyObject* args) {
     int tokens_size = 0;
     int tokens[strlen(text)];
 
-    log_debug("p_encode prefix='%s'", prefix);
     encode(text, vocab_encode, pattern, tokens, &tokens_size,
            (const char**)special_chars, prefix, is_byte_encoder);
 

--- a/src/lib.c
+++ b/src/lib.c
@@ -78,7 +78,9 @@ static PyObject* p_initialize(PyObject* self,
         return NULL;
     }
 
-    prefix = strdup(local_prefix);
+    if (local_prefix) {
+        prefix = strdup(local_prefix);
+    }
 
     log_debug("Initializing with vocab file: %s", vocab_file_path);
 

--- a/src/pretokenizer.c
+++ b/src/pretokenizer.c
@@ -1,0 +1,47 @@
+#include "hutoken/pretokenizer.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "hutoken/helper.h"
+
+char* pretokenizer_encode(const char* text, const char** special_chars) {
+    if (!text) {
+        return NULL;
+    }
+
+    size_t new_len = 0;
+    for (const char* p = text; *p != '\0'; p++) {
+        unsigned char current_char = (unsigned char)*p;
+
+        if (special_chars[current_char] != NULL) {
+            new_len += strlen(special_chars[current_char]);
+        } else {
+            new_len += 1;
+        }
+    }
+
+    char* result = (char*)malloc(new_len + 1);
+    if (!result) {
+        return NULL;
+    }
+
+    char* dest = result;
+    for (const char* p = text; *p != '\0'; ++p) {
+        unsigned char current_char = (unsigned char)*p;
+        const char* replacement = special_chars[current_char];
+
+        if (replacement != NULL) {
+            size_t repl_len = strlen(replacement);
+            memcpy(dest, replacement, repl_len);
+            dest += repl_len;
+        } else {
+            *dest = *p;
+            ++dest;
+        }
+    }
+    *dest = '\0';
+
+    return result;
+}

--- a/src/pretokenizer.c
+++ b/src/pretokenizer.c
@@ -1,17 +1,21 @@
 #include "hutoken/pretokenizer.h"
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include "hutoken/helper.h"
 
-char* pretokenizer_encode(const char* text, const char** special_chars) {
+char* pretokenizer_encode(const char* text,
+                          const char** special_chars,
+                          const char* prefix) {
     if (!text) {
         return NULL;
     }
 
-    size_t new_len = 0;
+    size_t prefix_len = (prefix != NULL) ? strlen(prefix) : 0;
+    size_t new_len = prefix_len;
     for (const char* p = text; *p != '\0'; p++) {
         unsigned char current_char = (unsigned char)*p;
 
@@ -28,6 +32,12 @@ char* pretokenizer_encode(const char* text, const char** special_chars) {
     }
 
     char* dest = result;
+
+    if (prefix_len > 0) {
+        memcpy(dest, prefix, prefix_len);
+        dest += prefix_len;
+    }
+
     for (const char* p = text; *p != '\0'; ++p) {
         unsigned char current_char = (unsigned char)*p;
         const char* replacement = special_chars[current_char];

--- a/src/pretokenizer.c
+++ b/src/pretokenizer.c
@@ -14,6 +14,7 @@ char* pretokenizer_encode(const char* text,
         return NULL;
     }
 
+    log_debug("prefix=%s", prefix);
     size_t prefix_len = (prefix != NULL) ? strlen(prefix) : 0;
     size_t new_len = prefix_len;
     for (const char* p = text; *p != '\0'; p++) {

--- a/src/pretokenizer.c
+++ b/src/pretokenizer.c
@@ -146,7 +146,7 @@ char* pretokenizer_encode(const char* text,
  * and return its Unicode code point.
  * Needed for tokenizers which use byte encoding.
  */
-uint32_t utf8_to_codepoint(const unsigned char *p, int *bytes_read) {
+uint32_t utf8_to_codepoint(const unsigned char* p, int* bytes_read) {
     uint32_t cp = 0;
     if (p[0] < 0x80) {
         cp = p[0];
@@ -158,7 +158,8 @@ uint32_t utf8_to_codepoint(const unsigned char *p, int *bytes_read) {
         cp = ((p[0] & 0x0F) << 12) | ((p[1] & 0x3F) << 6) | (p[2] & 0x3F);
         *bytes_read = 3;
     } else if ((p[0] & 0xF8) == 0xF0) {
-        cp = ((p[0] & 0x07) << 18) | ((p[1] & 0x3F) << 12) | ((p[2] & 0x3F) << 6) | (p[3] & 0x3F);
+        cp = ((p[0] & 0x07) << 18) | ((p[1] & 0x3F) << 12) |
+             ((p[2] & 0x3F) << 6) | (p[3] & 0x3F);
         *bytes_read = 4;
     } else {
         cp = 0xFFFD;
@@ -166,7 +167,6 @@ uint32_t utf8_to_codepoint(const unsigned char *p, int *bytes_read) {
     }
     return cp;
 }
-
 
 char* pretokenizer_decode(const char* text,
                           const char** special_chars,
@@ -204,7 +204,8 @@ char* pretokenizer_decode(const char* text,
 
             bool matched = false;
             for (int i = 0; i < 256; i++) {
-                if (special_chars[i] && strcmp(current_char_str, special_chars[i]) == 0) {
+                if (special_chars[i] &&
+                    strcmp(current_char_str, special_chars[i]) == 0) {
                     *dest++ = (unsigned char)i;
                     matched = true;
                     break;

--- a/src/pretokenizer.c
+++ b/src/pretokenizer.c
@@ -63,7 +63,7 @@ char* pretokenizer_encode(const char* text,
         is_special_dest += prefix_len;
     }
 
-    if(!is_byte_encoder){
+    if (!is_byte_encoder) {
         for (const char* p = text; *p != '\0';) {
             unsigned char current_char = (unsigned char)*p;
             int char_len = utf8_char_length((unsigned char*)p);
@@ -82,16 +82,14 @@ char* pretokenizer_encode(const char* text,
             }
 
             p += char_len;
-
         }
 
         *dest = '\0';
         *is_special_dest = '\0';
         return result;
-    }
-    else{
+    } else {
         const char* p = text;
-        while(*p != '\0') {
+        while (*p != '\0') {
             unsigned char current_char = (unsigned char)*p;
             int char_len = utf8_char_length(&current_char);
             const char* replacement = special_chars[current_char];
@@ -127,13 +125,12 @@ char* pretokenizer_encode(const char* text,
     for (size_t i = 0; i < result_len; ++i) {
         unsigned char current_char = (unsigned char)result[i];
 
-        if (is_special[i] == 'n' && current_char >= 0x80){
+        if (is_special[i] == 'n' && current_char >= 0x80) {
             unsigned char first_byte = 0xC0 | (current_char >> 6);
             unsigned char second_byte = 0x80 | (current_char & 0x3F);
             *bdest++ = first_byte;
             *bdest++ = second_byte;
-        }
-        else{
+        } else {
             *bdest++ = current_char;
         }
     }

--- a/src/pretokenizer.c
+++ b/src/pretokenizer.c
@@ -55,3 +55,49 @@ char* pretokenizer_encode(const char* text,
 
     return result;
 }
+
+char* pretokenizer_decode(const char* text, const char** special_chars,
+                          const char* prefix) {
+    if (!text) {
+        return NULL;
+    }
+    if (prefix){
+        size_t prefix_len = strlen(prefix);
+        if (strncmp(text, prefix, prefix_len) == 0) {
+            text += prefix_len;
+        }
+    }
+
+
+    size_t max_len = strlen(text);
+    char* result = (char*)malloc(max_len + 1);
+    if (!result) {
+        return NULL;
+    }
+
+    char* dest = result;
+
+    for (const char* p = text; *p != '\0';) {
+        bool matched = false;
+
+        for (int i = 0; i < 256; i++) {
+            const char* searched_char = special_chars[i];
+            if (searched_char && strncmp(p, searched_char, strlen(searched_char)) == 0) {
+                *dest = (unsigned char)i;
+                ++dest;
+                p += strlen(searched_char);
+                matched = true;
+                break;
+            }
+        }
+
+        if (!matched) {
+            *dest = (unsigned char)*p;
+            ++dest;
+            ++p;
+        }
+    }
+    *dest = '\0';
+
+    return result;
+}

--- a/src/pretokenizer.c
+++ b/src/pretokenizer.c
@@ -78,7 +78,7 @@ char* pretokenizer_encode(const char* text,
     }
     *dest = '\0';
     *is_special_dest = '\0';
-    
+
     if (is_special_out) {
         *is_special_out = is_special;
     } else {

--- a/src/pretokenizer.c
+++ b/src/pretokenizer.c
@@ -31,7 +31,6 @@ char* pretokenizer_encode(const char* text,
         return NULL;
     }
 
-    log_debug("prefix=%s", prefix);
     size_t prefix_len = (prefix != NULL) ? strlen(prefix) : 0;
     size_t new_len = prefix_len;
     for (const char* p = text; *p != '\0'; p++) {
@@ -142,49 +141,120 @@ char* pretokenizer_encode(const char* text,
     return byte_text;
 }
 
+/*
+ * A helper function to decode a single UTF-8 character from a byte stream
+ * and return its Unicode code point.
+ * Needed for tokenizers which use byte encoding.
+ */
+uint32_t utf8_to_codepoint(const unsigned char *p, int *bytes_read) {
+    uint32_t cp = 0;
+    if (p[0] < 0x80) {
+        cp = p[0];
+        *bytes_read = 1;
+    } else if ((p[0] & 0xE0) == 0xC0) {
+        cp = ((p[0] & 0x1F) << 6) | (p[1] & 0x3F);
+        *bytes_read = 2;
+    } else if ((p[0] & 0xF0) == 0xE0) {
+        cp = ((p[0] & 0x0F) << 12) | ((p[1] & 0x3F) << 6) | (p[2] & 0x3F);
+        *bytes_read = 3;
+    } else if ((p[0] & 0xF8) == 0xF0) {
+        cp = ((p[0] & 0x07) << 18) | ((p[1] & 0x3F) << 12) | ((p[2] & 0x3F) << 6) | (p[3] & 0x3F);
+        *bytes_read = 4;
+    } else {
+        cp = 0xFFFD;
+        *bytes_read = 1;
+    }
+    return cp;
+}
+
+
 char* pretokenizer_decode(const char* text,
                           const char** special_chars,
-                          const char* prefix) {
+                          const char* prefix,
+                          bool byte_level) {
     if (!text) {
         return NULL;
     }
+
+    size_t text_len = strlen(text);
     if (prefix) {
         size_t prefix_len = strlen(prefix);
         if (strncmp(text, prefix, prefix_len) == 0) {
             text += prefix_len;
+            text_len -= prefix_len;
         }
     }
 
-    size_t max_len = strlen(text);
-    char* result = (char*)malloc(max_len + 1);
-    if (!result) {
+    char* buffer = (char*)malloc(text_len + 1);
+    if (!buffer) {
         return NULL;
     }
+    char* dest = buffer;
 
-    char* dest = result;
+    const char* p = text;
 
-    for (const char* p = text; *p != '\0';) {
-        bool matched = false;
+    if (byte_level) {
+        const unsigned char* up = (const unsigned char*)p;
+        while (*up != '\0') {
+            int bytes_in_char = 0;
+            uint32_t codepoint = utf8_to_codepoint(up, &bytes_in_char);
 
-        for (int i = 0; i < 256; i++) {
-            const char* searched_char = special_chars[i];
-            if (searched_char &&
-                strncmp(p, searched_char, strlen(searched_char)) == 0) {
-                *dest = (unsigned char)i;
-                ++dest;
-                p += strlen(searched_char);
-                matched = true;
-                break;
+            char current_char_str[5] = {0};
+            strncpy(current_char_str, (const char*)up, bytes_in_char);
+
+            bool matched = false;
+            for (int i = 0; i < 256; i++) {
+                if (special_chars[i] && strcmp(current_char_str, special_chars[i]) == 0) {
+                    *dest++ = (unsigned char)i;
+                    matched = true;
+                    break;
+                }
+            }
+
+            if (!matched) {
+                if (codepoint < 256) {
+                    *dest++ = (unsigned char)codepoint;
+                } else {
+                    *dest++ = '?';
+                }
+            }
+            up += bytes_in_char;
+        }
+    } else {
+        while (*p != '\0') {
+            bool matched = false;
+            for (int i = 0; i < 256; i++) {
+                if (special_chars[i]) {
+                    size_t tok_len = strlen(special_chars[i]);
+                    if (strncmp(p, special_chars[i], tok_len) == 0) {
+                        *dest++ = (unsigned char)i;
+                        p += tok_len;
+                        matched = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!matched) {
+                int char_len = utf8_char_length((const unsigned char*)p);
+                memcpy(dest, p, char_len);
+                dest += char_len;
+                p += char_len;
             }
         }
-
-        if (!matched) {
-            *dest = (unsigned char)*p;
-            ++dest;
-            ++p;
-        }
     }
+
     *dest = '\0';
+
+    size_t final_len = dest - buffer;
+    char* result = (char*)malloc(final_len + 1);
+    if (!result) {
+        free(buffer);
+        return NULL;
+    }
+    memcpy(result, buffer, final_len);
+    result[final_len] = '\0';
+    free(buffer);
 
     return result;
 }

--- a/src/pretokenizer.c
+++ b/src/pretokenizer.c
@@ -121,16 +121,18 @@ char* pretokenizer_encode(const char* text,
 
     char* bdest = byte_text;
 
-    for (size_t i = 0; i < result_len; ++i) {
-        unsigned char current_char = (unsigned char)result[i];
+    if (dest != result) {
+        for (size_t i = 0; i < result_len; ++i) {
+            unsigned char current_char = (unsigned char)result[i];
 
-        if (is_special[i] == 'n' && current_char >= 0x80) {
-            unsigned char first_byte = 0xC0 | (current_char >> 6);
-            unsigned char second_byte = 0x80 | (current_char & 0x3F);
-            *bdest++ = first_byte;
-            *bdest++ = second_byte;
-        } else {
-            *bdest++ = current_char;
+            if (is_special[i] == 'n' && current_char >= 0x80) {
+                unsigned char first_byte = 0xC0 | (current_char >> 6);
+                unsigned char second_byte = 0x80 | (current_char & 0x3F);
+                *bdest++ = first_byte;
+                *bdest++ = second_byte;
+            } else {
+                *bdest++ = current_char;
+            }
         }
     }
     *bdest = '\0';

--- a/src/pretokenizer.c
+++ b/src/pretokenizer.c
@@ -56,18 +56,18 @@ char* pretokenizer_encode(const char* text,
     return result;
 }
 
-char* pretokenizer_decode(const char* text, const char** special_chars,
+char* pretokenizer_decode(const char* text,
+                          const char** special_chars,
                           const char* prefix) {
     if (!text) {
         return NULL;
     }
-    if (prefix){
+    if (prefix) {
         size_t prefix_len = strlen(prefix);
         if (strncmp(text, prefix, prefix_len) == 0) {
             text += prefix_len;
         }
     }
-
 
     size_t max_len = strlen(text);
     char* result = (char*)malloc(max_len + 1);
@@ -82,7 +82,8 @@ char* pretokenizer_decode(const char* text, const char** special_chars,
 
         for (int i = 0; i < 256; i++) {
             const char* searched_char = special_chars[i];
-            if (searched_char && strncmp(p, searched_char, strlen(searched_char)) == 0) {
+            if (searched_char &&
+                strncmp(p, searched_char, strlen(searched_char)) == 0) {
                 *dest = (unsigned char)i;
                 ++dest;
                 p += strlen(searched_char);

--- a/src/pretokenizer.c
+++ b/src/pretokenizer.c
@@ -84,13 +84,12 @@ char* pretokenizer_encode(const char* text,
         }
 
         *dest = '\0';
-        *is_special_dest = '\0';
+        free(is_special);
         return result;
     } else {
         const char* p = text;
         while (*p != '\0') {
             unsigned char current_char = (unsigned char)*p;
-            int char_len = utf8_char_length(&current_char);
             const char* replacement = special_chars[current_char];
 
             if (replacement != NULL) {
@@ -115,6 +114,7 @@ char* pretokenizer_encode(const char* text,
 
     char* byte_text = malloc(result_len * 2 + 1);
     if (!byte_text) {
+        free(is_special);
         free(result);
         return NULL;
     }

--- a/src/string.c
+++ b/src/string.c
@@ -113,6 +113,22 @@ enum StringError string_append(struct String* str, const char* to_append) {
     return STRING_SUCCESS;
 }
 
+enum StringError string_clear(struct String* str) {
+    if (!str) {
+        return STRING_INVALID_ARGUMENT;
+    }
+
+    if (str->is_large) {
+        str->data.large.len = 0;
+        str->data.large.buf[0] = '\0';
+    } else {
+        str->data.small[0] = '\0';
+        str->data.small[STRING_SSO_MAX_LEN] = STRING_SSO_MAX_LEN;
+    }
+
+    return STRING_SUCCESS;
+}
+
 static enum StringError grow(struct String* str, size_t needed_len) {
     size_t capacity =
         str->is_large ? str->data.large.capacity : STRING_SSO_MAX_LEN;

--- a/src/string.c
+++ b/src/string.c
@@ -1,0 +1,152 @@
+#include "hutoken/string.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+static enum StringError grow(struct String* str, size_t needed_len);
+
+enum StringError string_init(struct String* str, const char* init) {
+    if (!str) {
+        return STRING_INVALID_ARGUMENT;
+    }
+
+    size_t len = init ? strlen(init) : 0;
+
+    if (len <= STRING_SSO_MAX_LEN) {
+        str->is_large = false;
+        if (init) {
+            memcpy(str->data.small, init, len);
+        }
+        str->data.small[STRING_SSO_MAX_LEN] = STRING_SSO_MAX_LEN - len;
+        str->data.small[len] = '\0';
+    } else {
+        str->is_large = true;
+        str->data.large.buf = (char*)malloc(len + 1);
+        if (!str->data.large.buf) {
+            return STRING_ALLOC_ERROR;
+        }
+
+        memcpy(str->data.large.buf, init, len);
+        str->data.large.buf[len] = '\0';
+        str->data.large.len = len;
+        str->data.large.capacity = len;
+    }
+
+    return STRING_SUCCESS;
+}
+
+enum StringError string_with_capacity(struct String* str, size_t capacity) {
+    if (!str) {
+        return STRING_INVALID_ARGUMENT;
+    }
+
+    if (capacity <= STRING_SSO_MAX_LEN) {
+        str->is_large = false;
+        str->data.small[STRING_SSO_MAX_LEN] = STRING_SSO_MAX_LEN;
+        str->data.small[0] = '\0';
+    } else {
+        str->is_large = true;
+        str->data.large.buf = (char*)malloc(capacity + 1);
+        if (!str->data.large.buf) {
+            return STRING_ALLOC_ERROR;
+        }
+        str->data.large.buf[0] = '\0';
+        str->data.large.len = 0;
+        str->data.large.capacity = capacity;
+    }
+
+    return STRING_SUCCESS;
+}
+
+void string_release(struct String* str) {
+    if (str && str->is_large) {
+        free(str->data.large.buf);
+    }
+}
+
+const char* string_c_str(const struct String* str) {
+    if (!str) {
+        return "";
+    }
+
+    return str->is_large ? str->data.large.buf : str->data.small;
+}
+
+size_t string_len(const struct String* str) {
+    if (!str) {
+        return 0;
+    }
+
+    if (str->is_large) {
+        return str->data.large.len;
+    }
+
+    return STRING_SSO_MAX_LEN - str->data.small[STRING_SSO_MAX_LEN];
+}
+
+enum StringError string_append(struct String* str, const char* to_append) {
+    if (!str || !to_append) {
+        return STRING_INVALID_ARGUMENT;
+    }
+
+    size_t current_len = string_len(str);
+    size_t append_len = strlen(to_append);
+    if (append_len == 0) {
+        return STRING_SUCCESS;
+    }
+
+    size_t needed_len = current_len + append_len;
+    if (grow(str, needed_len) != STRING_SUCCESS) {
+        return STRING_ALLOC_ERROR;
+    }
+
+    char* buffer = str->is_large ? str->data.large.buf : str->data.small;
+    memcpy(buffer + current_len, to_append, append_len);
+    buffer[needed_len] = '\0';
+
+    if (str->is_large) {
+        str->data.large.len = needed_len;
+    } else {
+        str->data.small[STRING_SSO_MAX_LEN] = STRING_SSO_MAX_LEN - needed_len;
+    }
+
+    return STRING_SUCCESS;
+}
+
+static enum StringError grow(struct String* str, size_t needed_len) {
+    size_t capacity =
+        str->is_large ? str->data.large.capacity : STRING_SSO_MAX_LEN;
+    if (needed_len <= capacity) {
+        return STRING_SUCCESS;
+    }
+
+    size_t new_capacity = capacity < 8 ? 8 : capacity;
+    while (new_capacity <= needed_len) {
+        new_capacity *= 2;
+    }
+
+    if (str->is_large) {
+        char* new_buf = realloc(str->data.large.buf, new_capacity + 1);
+        if (!new_buf) {
+            return STRING_ALLOC_ERROR;
+        }
+
+        str->data.large.buf = new_buf;
+        str->data.large.capacity = new_capacity;
+    } else {
+        char* new_buf = malloc(new_capacity + 1);
+        if (!new_buf) {
+            return STRING_ALLOC_ERROR;
+        }
+
+        size_t old_len = string_len(str);
+        memcpy(new_buf, str->data.small, old_len);
+
+        str->is_large = true;
+        str->data.large.buf = new_buf;
+        str->data.large.len = old_len;
+        str->data.large.capacity = new_capacity;
+    }
+
+    return STRING_SUCCESS;
+}

--- a/src/string.c
+++ b/src/string.c
@@ -113,6 +113,38 @@ enum StringError string_append(struct String* str, const char* to_append) {
     return STRING_SUCCESS;
 }
 
+enum StringError string_append_n(struct String* str,
+                                 const char* to_append,
+                                 size_t n) {
+    if (!str || !to_append) {
+        return STRING_INVALID_ARGUMENT;
+    }
+
+    if (n == 0) {
+        return STRING_SUCCESS;
+    }
+
+    size_t current_len = string_len(str);
+    size_t needed_len = current_len + n;
+
+    if (grow(str, needed_len) != STRING_SUCCESS) {
+        return STRING_ALLOC_ERROR;
+    }
+
+    char* buffer = str->is_large ? str->data.large.buf : str->data.small;
+
+    memcpy(buffer + current_len, to_append, n);
+    buffer[needed_len] = '\0';
+
+    if (str->is_large) {
+        str->data.large.len = needed_len;
+    } else {
+        str->data.small[STRING_SSO_MAX_LEN] = STRING_SSO_MAX_LEN - needed_len;
+    }
+
+    return STRING_SUCCESS;
+}
+
 enum StringError string_clear(struct String* str) {
     if (!str) {
         return STRING_INVALID_ARGUMENT;

--- a/tests/test_hashmap.c
+++ b/tests/test_hashmap.c
@@ -1,29 +1,27 @@
+#include <assert.h>
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
 
 #include "hashmap.h"
 
-
 int main() {
+    struct HashMap* map = hashmap_new(16);
 
-    struct HashMap *map = hashmap_new(16);
-
-    struct Token token1 = { .key = "key1", .value = 1 };
-    struct Token token2 = { .key = "key2", .value = 2 };
-    struct Token token3 = { .key = "key3", .value = 3 };
+    struct Token token1 = {.key = "key1", .value = 1};
+    struct Token token2 = {.key = "key2", .value = 2};
+    struct Token token3 = {.key = "key3", .value = 3};
 
     assert(hashmap_set(map, &token1) == NULL);
     assert(hashmap_set(map, &token2) == NULL);
     assert(hashmap_set(map, &token3) == NULL);
 
-    struct Token *result = (struct Token *)hashmap_get(map, &token1);
+    struct Token* result = (struct Token*)hashmap_get(map, &token1);
     assert(result && result->value == 1);
 
-    result = (struct Token *)hashmap_get(map, &token2);
+    result = (struct Token*)hashmap_get(map, &token2);
     assert(result && result->value == 2);
 
-    result = (struct Token *)hashmap_get(map, &token3);
+    result = (struct Token*)hashmap_get(map, &token3);
     assert(result && result->value == 3);
 
     assert(hashmap_count(map) == 3);

--- a/tests/test_pretokenizer.c
+++ b/tests/test_pretokenizer.c
@@ -25,7 +25,8 @@ void test_no_replacements_needed(void) {
     const char* replacements[256] = {NULL};
 
     char* result_encoded = pretokenizer_encode(text, replacements, NULL);
-    char* result_decoded = pretokenizer_decode(result_encoded, replacements, NULL);
+    char* result_decoded =
+        pretokenizer_decode(result_encoded, replacements, NULL);
 
     assert(strcmp(result_encoded, "hello world") == 0);
     assert(strcmp(result_decoded, text) == 0);
@@ -40,7 +41,8 @@ void test_single_replacement_at_start(void) {
     replacements['a'] = "Alpha";
 
     char* result_encoded = pretokenizer_encode(text, replacements, NULL);
-    char* result_decoded = pretokenizer_decode(result_encoded, replacements, NULL);
+    char* result_decoded =
+        pretokenizer_decode(result_encoded, replacements, NULL);
 
     assert(strcmp(result_encoded, "Alphapple") == 0);
     assert(strcmp(result_decoded, text) == 0);
@@ -55,7 +57,8 @@ void test_single_replacement_at_end(void) {
     replacements['e'] = "End";
 
     char* result_encoded = pretokenizer_encode(text, replacements, NULL);
-    char* result_decoded = pretokenizer_decode(result_encoded, replacements, NULL);
+    char* result_decoded =
+        pretokenizer_decode(result_encoded, replacements, NULL);
 
     assert(strcmp(result_encoded, "applEnd") == 0);
     assert(strcmp(result_decoded, text) == 0);
@@ -70,7 +73,8 @@ void test_single_replacement_in_middle(void) {
     replacements['p'] = "P";
 
     char* result_encoded = pretokenizer_encode(text, replacements, NULL);
-    char* result_decoded = pretokenizer_decode(result_encoded, replacements, NULL);
+    char* result_decoded =
+        pretokenizer_decode(result_encoded, replacements, NULL);
 
     assert(strcmp(result_encoded, "aPPle") == 0);
     assert(strcmp(result_decoded, text) == 0);
@@ -86,7 +90,8 @@ void test_multiple_different_replacements(void) {
     replacements['e'] = "ef";
 
     char* result_encoded = pretokenizer_encode(text, replacements, NULL);
-    char* result_decoded = pretokenizer_decode(result_encoded, replacements, NULL);
+    char* result_decoded =
+        pretokenizer_decode(result_encoded, replacements, NULL);
 
     assert(strcmp(result_encoded, "abpplef") == 0);
     assert(strcmp(result_decoded, text) == 0);
@@ -101,7 +106,8 @@ void test_multiple_occurrences_of_same_char(void) {
     replacements['a'] = "o";
 
     char* result_encoded = pretokenizer_encode(text, replacements, NULL);
-    char* result_decoded = pretokenizer_decode(result_encoded, replacements, NULL);
+    char* result_decoded =
+        pretokenizer_decode(result_encoded, replacements, NULL);
 
     assert(strcmp(result_encoded, "bonono") == 0);
     assert(strcmp(result_decoded, text) == 0);
@@ -130,7 +136,8 @@ void test_empty_input_string(void) {
     replacements['a'] = "b";
 
     char* result_encoded = pretokenizer_encode(text, replacements, NULL);
-    char* result_decoded = pretokenizer_decode(result_encoded, replacements, NULL);
+    char* result_decoded =
+        pretokenizer_decode(result_encoded, replacements, NULL);
 
     assert(strcmp(result_encoded, "") == 0);
     assert(strcmp(result_decoded, text) == 0);
@@ -147,7 +154,8 @@ void test_all_chars_are_replaced(void) {
     replacements['c'] = "333";
 
     char* result_encoded = pretokenizer_encode(text, replacements, NULL);
-    char* result_decoded = pretokenizer_decode(result_encoded, replacements, NULL);
+    char* result_decoded =
+        pretokenizer_decode(result_encoded, replacements, NULL);
 
     assert(strcmp(result_encoded, "122333") == 0);
     assert(strcmp(result_decoded, text) == 0);
@@ -162,7 +170,8 @@ void test_replacement_with_single_char(void) {
     replacements['t'] = "T";
 
     char* result_encoded = pretokenizer_encode(text, replacements, NULL);
-    char* result_decoded = pretokenizer_decode(result_encoded, replacements, NULL);
+    char* result_decoded =
+        pretokenizer_decode(result_encoded, replacements, NULL);
 
     assert(strcmp(result_encoded, "TesT") == 0);
     assert(strcmp(result_decoded, text) == 0);
@@ -179,7 +188,8 @@ void test_with_prefix_and_replacements(void) {
     const char* prefix = "Juicy ";
 
     char* result_encoded = pretokenizer_encode(text, replacements, prefix);
-    char* result_decoded = pretokenizer_decode(result_encoded, replacements, prefix);
+    char* result_decoded =
+        pretokenizer_decode(result_encoded, replacements, prefix);
 
     assert(strcmp(result_encoded, "Juicy ApplE") == 0);
     assert(strcmp(result_decoded, text) == 0);
@@ -209,7 +219,8 @@ void test_with_prefix_and_empty_input_string(void) {
     const char* prefix = "Start:";
 
     char* result_encoded = pretokenizer_encode(text, replacements, prefix);
-    char* result_decoded = pretokenizer_decode(result_encoded, replacements, prefix);
+    char* result_decoded =
+        pretokenizer_decode(result_encoded, replacements, prefix);
 
     assert(strcmp(result_encoded, "Start:") == 0);
     assert(strcmp(result_decoded, text) == 0);
@@ -224,7 +235,8 @@ void test_with_empty_string_as_prefix(void) {
     const char* prefix = "";
 
     char* result_encoded = pretokenizer_encode(text, replacements, prefix);
-    char* result_decoded = pretokenizer_decode(result_encoded, replacements, prefix);
+    char* result_decoded =
+        pretokenizer_decode(result_encoded, replacements, prefix);
 
     assert(strcmp(result_encoded, "test") == 0);
     assert(strcmp(result_decoded, text) == 0);

--- a/tests/test_pretokenizer.c
+++ b/tests/test_pretokenizer.c
@@ -187,7 +187,8 @@ void test_with_prefix_and_replacements(void) {
     replacements['e'] = "E";
     const char* prefix = "Juicy ";
 
-    char* result_encoded = pretokenizer_encode(text, replacements, prefix, false);
+    char* result_encoded =
+        pretokenizer_encode(text, replacements, prefix, false);
     char* result_decoded =
         pretokenizer_decode(result_encoded, replacements, prefix, false);
 
@@ -218,7 +219,8 @@ void test_with_prefix_and_empty_input_string(void) {
     const char* replacements[256] = {NULL};
     const char* prefix = "Start:";
 
-    char* result_encoded = pretokenizer_encode(text, replacements, prefix, false);
+    char* result_encoded =
+        pretokenizer_encode(text, replacements, prefix, false);
     char* result_decoded =
         pretokenizer_decode(result_encoded, replacements, prefix, false);
 
@@ -234,7 +236,8 @@ void test_with_empty_string_as_prefix(void) {
     const char* replacements[256] = {NULL};
     const char* prefix = "";
 
-    char* result_encoded = pretokenizer_encode(text, replacements, prefix, false);
+    char* result_encoded =
+        pretokenizer_encode(text, replacements, prefix, false);
     char* result_decoded =
         pretokenizer_decode(result_encoded, replacements, prefix, false);
 
@@ -251,8 +254,10 @@ void test_with_multibyte_char(void) {
     const char* prefix = NULL;
     replacements[145] = "ĳ";
 
-    char* result_encoded = pretokenizer_encode(text, replacements, prefix, true);
-    char* result_decoded = pretokenizer_decode(result_encoded, replacements, prefix, true);
+    char* result_encoded =
+        pretokenizer_encode(text, replacements, prefix, true);
+    char* result_decoded =
+        pretokenizer_decode(result_encoded, replacements, prefix, true);
 
     assert(strcmp(result_decoded, text) == 0);
 

--- a/tests/test_pretokenizer.c
+++ b/tests/test_pretokenizer.c
@@ -1,0 +1,161 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "hutoken/pretokenizer.h"
+
+#define RUN_TEST(test)                          \
+    do {                                        \
+        printf("Running test: %s...\n", #test); \
+        test();                                 \
+    } while (0)
+
+void test_null_input_string(void) {
+    const char* replacements[256] = {NULL};
+    char* result = pretokenizer_encode(NULL, replacements);
+
+    assert(result == NULL);
+}
+
+void test_no_replacements_needed(void) {
+    const char* text = "hello world";
+    const char* replacements[256] = {NULL};
+
+    char* result = pretokenizer_encode(text, replacements);
+
+    assert(strcmp(result, "hello world") == 0);
+
+    free(result);
+}
+
+void test_single_replacement_at_start(void) {
+    const char* text = "apple";
+    const char* replacements[256] = {NULL};
+    replacements['a'] = "Alpha";
+
+    char* result = pretokenizer_encode(text, replacements);
+
+    assert(strcmp(result, "Alphapple") == 0);
+
+    free(result);
+}
+
+void test_single_replacement_at_end(void) {
+    const char* text = "apple";
+    const char* replacements[256] = {NULL};
+    replacements['e'] = "End";
+
+    char* result = pretokenizer_encode(text, replacements);
+
+    assert(strcmp(result, "applEnd") == 0);
+
+    free(result);
+}
+
+void test_single_replacement_in_middle(void) {
+    const char* text = "apple";
+    const char* replacements[256] = {NULL};
+    replacements['p'] = "P";
+
+    char* result = pretokenizer_encode(text, replacements);
+
+    assert(strcmp(result, "aPPle") == 0);
+
+    free(result);
+}
+
+void test_multiple_different_replacements(void) {
+    const char* text = "apple";
+    const char* replacements[256] = {NULL};
+    replacements['a'] = "ab";
+    replacements['e'] = "ef";
+
+    char* result = pretokenizer_encode(text, replacements);
+
+    assert(strcmp(result, "abpplef") == 0);
+
+    free(result);
+}
+
+void test_multiple_occurrences_of_same_char(void) {
+    const char* text = "banana";
+    const char* replacements[256] = {NULL};
+    replacements['a'] = "o";
+
+    char* result = pretokenizer_encode(text, replacements);
+
+    assert(strcmp(result, "bonono") == 0);
+
+    free(result);
+}
+
+void test_replacement_with_empty_string(void) {
+    const char* text = "hello";
+    const char* replacements[256] = {NULL};
+    replacements['l'] = "";
+
+    char* result = pretokenizer_encode(text, replacements);
+
+    assert(strcmp(result, "heo") == 0);
+
+    free(result);
+}
+
+void test_empty_input_string(void) {
+    const char* text = "";
+    const char* replacements[256] = {NULL};
+    replacements['a'] = "b";
+
+    char* result = pretokenizer_encode(text, replacements);
+
+    assert(strcmp(result, "") == 0);
+
+    free(result);
+}
+
+void test_all_chars_are_replaced(void) {
+    const char* text = "abc";
+    const char* replacements[256] = {NULL};
+    replacements['a'] = "1";
+    replacements['b'] = "22";
+    replacements['c'] = "333";
+
+    char* result = pretokenizer_encode(text, replacements);
+
+    assert(strcmp(result, "122333") == 0);
+
+    free(result);
+}
+
+void test_replacement_with_single_char(void) {
+    const char* text = "test";
+    const char* replacements[256] = {NULL};
+    replacements['t'] = "T";
+
+    char* result = pretokenizer_encode(text, replacements);
+
+    assert(strcmp(result, "TesT") == 0);
+
+    free(result);
+}
+
+int main(void) {
+    puts("Starting string tests.\n");
+
+    RUN_TEST(test_null_input_string);
+    RUN_TEST(test_no_replacements_needed);
+    RUN_TEST(test_single_replacement_at_start);
+    RUN_TEST(test_single_replacement_at_end);
+    RUN_TEST(test_single_replacement_in_middle);
+    RUN_TEST(test_multiple_different_replacements);
+    RUN_TEST(test_multiple_occurrences_of_same_char);
+    RUN_TEST(test_replacement_with_empty_string);
+    RUN_TEST(test_empty_input_string);
+    RUN_TEST(test_all_chars_are_replaced);
+    RUN_TEST(test_replacement_with_single_char);
+
+    puts("\nAll tests passed successfully!");
+
+    return EXIT_SUCCESS;
+}

--- a/tests/test_pretokenizer.c
+++ b/tests/test_pretokenizer.c
@@ -13,20 +13,25 @@
 
 void test_null_input_string(void) {
     const char* replacements[256] = {NULL};
-    char* result = pretokenizer_encode(NULL, replacements, NULL);
+    char* result_encoded = pretokenizer_encode(NULL, replacements, NULL);
+    char* result_decoded = pretokenizer_decode(NULL, replacements, NULL);
 
-    assert(result == NULL);
+    assert(result_encoded == NULL);
+    assert(result_decoded == NULL);
 }
 
 void test_no_replacements_needed(void) {
     const char* text = "hello world";
     const char* replacements[256] = {NULL};
 
-    char* result = pretokenizer_encode(text, replacements, NULL);
+    char* result_encoded = pretokenizer_encode(text, replacements, NULL);
+    char* result_decoded = pretokenizer_decode(result_encoded, replacements, NULL);
 
-    assert(strcmp(result, "hello world") == 0);
+    assert(strcmp(result_encoded, "hello world") == 0);
+    assert(strcmp(result_decoded, text) == 0);
 
-    free(result);
+    free(result_encoded);
+    free(result_decoded);
 }
 
 void test_single_replacement_at_start(void) {
@@ -34,11 +39,14 @@ void test_single_replacement_at_start(void) {
     const char* replacements[256] = {NULL};
     replacements['a'] = "Alpha";
 
-    char* result = pretokenizer_encode(text, replacements, NULL);
+    char* result_encoded = pretokenizer_encode(text, replacements, NULL);
+    char* result_decoded = pretokenizer_decode(result_encoded, replacements, NULL);
 
-    assert(strcmp(result, "Alphapple") == 0);
+    assert(strcmp(result_encoded, "Alphapple") == 0);
+    assert(strcmp(result_decoded, text) == 0);
 
-    free(result);
+    free(result_encoded);
+    free(result_decoded);
 }
 
 void test_single_replacement_at_end(void) {
@@ -46,11 +54,14 @@ void test_single_replacement_at_end(void) {
     const char* replacements[256] = {NULL};
     replacements['e'] = "End";
 
-    char* result = pretokenizer_encode(text, replacements, NULL);
+    char* result_encoded = pretokenizer_encode(text, replacements, NULL);
+    char* result_decoded = pretokenizer_decode(result_encoded, replacements, NULL);
 
-    assert(strcmp(result, "applEnd") == 0);
+    assert(strcmp(result_encoded, "applEnd") == 0);
+    assert(strcmp(result_decoded, text) == 0);
 
-    free(result);
+    free(result_encoded);
+    free(result_decoded);
 }
 
 void test_single_replacement_in_middle(void) {
@@ -58,11 +69,14 @@ void test_single_replacement_in_middle(void) {
     const char* replacements[256] = {NULL};
     replacements['p'] = "P";
 
-    char* result = pretokenizer_encode(text, replacements, NULL);
+    char* result_encoded = pretokenizer_encode(text, replacements, NULL);
+    char* result_decoded = pretokenizer_decode(result_encoded, replacements, NULL);
 
-    assert(strcmp(result, "aPPle") == 0);
+    assert(strcmp(result_encoded, "aPPle") == 0);
+    assert(strcmp(result_decoded, text) == 0);
 
-    free(result);
+    free(result_encoded);
+    free(result_decoded);
 }
 
 void test_multiple_different_replacements(void) {
@@ -71,11 +85,14 @@ void test_multiple_different_replacements(void) {
     replacements['a'] = "ab";
     replacements['e'] = "ef";
 
-    char* result = pretokenizer_encode(text, replacements, NULL);
+    char* result_encoded = pretokenizer_encode(text, replacements, NULL);
+    char* result_decoded = pretokenizer_decode(result_encoded, replacements, NULL);
 
-    assert(strcmp(result, "abpplef") == 0);
+    assert(strcmp(result_encoded, "abpplef") == 0);
+    assert(strcmp(result_decoded, text) == 0);
 
-    free(result);
+    free(result_encoded);
+    free(result_decoded);
 }
 
 void test_multiple_occurrences_of_same_char(void) {
@@ -83,13 +100,18 @@ void test_multiple_occurrences_of_same_char(void) {
     const char* replacements[256] = {NULL};
     replacements['a'] = "o";
 
-    char* result = pretokenizer_encode(text, replacements, NULL);
+    char* result_encoded = pretokenizer_encode(text, replacements, NULL);
+    char* result_decoded = pretokenizer_decode(result_encoded, replacements, NULL);
 
-    assert(strcmp(result, "bonono") == 0);
+    assert(strcmp(result_encoded, "bonono") == 0);
+    assert(strcmp(result_decoded, text) == 0);
 
-    free(result);
+    free(result_encoded);
+    free(result_decoded);
 }
 
+// won't happen in practice
+// decoding will not be able to handle this
 void test_replacement_with_empty_string(void) {
     const char* text = "hello";
     const char* replacements[256] = {NULL};
@@ -107,11 +129,14 @@ void test_empty_input_string(void) {
     const char* replacements[256] = {NULL};
     replacements['a'] = "b";
 
-    char* result = pretokenizer_encode(text, replacements, NULL);
+    char* result_encoded = pretokenizer_encode(text, replacements, NULL);
+    char* result_decoded = pretokenizer_decode(result_encoded, replacements, NULL);
 
-    assert(strcmp(result, "") == 0);
+    assert(strcmp(result_encoded, "") == 0);
+    assert(strcmp(result_decoded, text) == 0);
 
-    free(result);
+    free(result_encoded);
+    free(result_decoded);
 }
 
 void test_all_chars_are_replaced(void) {
@@ -121,11 +146,14 @@ void test_all_chars_are_replaced(void) {
     replacements['b'] = "22";
     replacements['c'] = "333";
 
-    char* result = pretokenizer_encode(text, replacements, NULL);
+    char* result_encoded = pretokenizer_encode(text, replacements, NULL);
+    char* result_decoded = pretokenizer_decode(result_encoded, replacements, NULL);
 
-    assert(strcmp(result, "122333") == 0);
+    assert(strcmp(result_encoded, "122333") == 0);
+    assert(strcmp(result_decoded, text) == 0);
 
-    free(result);
+    free(result_encoded);
+    free(result_decoded);
 }
 
 void test_replacement_with_single_char(void) {
@@ -133,11 +161,14 @@ void test_replacement_with_single_char(void) {
     const char* replacements[256] = {NULL};
     replacements['t'] = "T";
 
-    char* result = pretokenizer_encode(text, replacements, NULL);
+    char* result_encoded = pretokenizer_encode(text, replacements, NULL);
+    char* result_decoded = pretokenizer_decode(result_encoded, replacements, NULL);
 
-    assert(strcmp(result, "TesT") == 0);
+    assert(strcmp(result_encoded, "TesT") == 0);
+    assert(strcmp(result_decoded, text) == 0);
 
-    free(result);
+    free(result_encoded);
+    free(result_decoded);
 }
 
 void test_with_prefix_and_replacements(void) {
@@ -145,20 +176,27 @@ void test_with_prefix_and_replacements(void) {
     const char* replacements[256] = {NULL};
     replacements['a'] = "A";
     replacements['e'] = "E";
+    const char* prefix = "Juicy ";
 
-    char* result = pretokenizer_encode(text, replacements, "Juicy ");
+    char* result_encoded = pretokenizer_encode(text, replacements, prefix);
+    char* result_decoded = pretokenizer_decode(result_encoded, replacements, prefix);
 
-    assert(strcmp(result, "Juicy ApplE") == 0);
+    assert(strcmp(result_encoded, "Juicy ApplE") == 0);
+    assert(strcmp(result_decoded, text) == 0);
 
-    free(result);
+    free(result_encoded);
+    free(result_decoded);
 }
 
+// won't happen in practice
+// decoding will not be able to handle this
 void test_with_prefix_and_empty_string_replacement(void) {
     const char* text = "-abc-";
     const char* replacements[256] = {NULL};
     replacements['-'] = "";
+    const char* prefix = "Prefix:";
 
-    char* result = pretokenizer_encode(text, replacements, "Prefix:");
+    char* result = pretokenizer_encode(text, replacements, prefix);
 
     assert(strcmp(result, "Prefix:abc") == 0);
 
@@ -168,23 +206,31 @@ void test_with_prefix_and_empty_string_replacement(void) {
 void test_with_prefix_and_empty_input_string(void) {
     const char* text = "";
     const char* replacements[256] = {NULL};
+    const char* prefix = "Start:";
 
-    char* result = pretokenizer_encode(text, replacements, "Start:");
+    char* result_encoded = pretokenizer_encode(text, replacements, prefix);
+    char* result_decoded = pretokenizer_decode(result_encoded, replacements, prefix);
 
-    assert(strcmp(result, "Start:") == 0);
+    assert(strcmp(result_encoded, "Start:") == 0);
+    assert(strcmp(result_decoded, text) == 0);
 
-    free(result);
+    free(result_encoded);
+    free(result_decoded);
 }
 
 void test_with_empty_string_as_prefix(void) {
     const char* text = "test";
     const char* replacements[256] = {NULL};
+    const char* prefix = "";
 
-    char* result = pretokenizer_encode(text, replacements, "");
+    char* result_encoded = pretokenizer_encode(text, replacements, prefix);
+    char* result_decoded = pretokenizer_decode(result_encoded, replacements, prefix);
 
-    assert(strcmp(result, "test") == 0);
+    assert(strcmp(result_encoded, "test") == 0);
+    assert(strcmp(result_decoded, text) == 0);
 
-    free(result);
+    free(result_encoded);
+    free(result_decoded);
 }
 
 int main(void) {

--- a/tests/test_pretokenizer.c
+++ b/tests/test_pretokenizer.c
@@ -13,7 +13,7 @@
 
 void test_null_input_string(void) {
     const char* replacements[256] = {NULL};
-    char* result = pretokenizer_encode(NULL, replacements);
+    char* result = pretokenizer_encode(NULL, replacements, NULL);
 
     assert(result == NULL);
 }
@@ -22,7 +22,7 @@ void test_no_replacements_needed(void) {
     const char* text = "hello world";
     const char* replacements[256] = {NULL};
 
-    char* result = pretokenizer_encode(text, replacements);
+    char* result = pretokenizer_encode(text, replacements, NULL);
 
     assert(strcmp(result, "hello world") == 0);
 
@@ -34,7 +34,7 @@ void test_single_replacement_at_start(void) {
     const char* replacements[256] = {NULL};
     replacements['a'] = "Alpha";
 
-    char* result = pretokenizer_encode(text, replacements);
+    char* result = pretokenizer_encode(text, replacements, NULL);
 
     assert(strcmp(result, "Alphapple") == 0);
 
@@ -46,7 +46,7 @@ void test_single_replacement_at_end(void) {
     const char* replacements[256] = {NULL};
     replacements['e'] = "End";
 
-    char* result = pretokenizer_encode(text, replacements);
+    char* result = pretokenizer_encode(text, replacements, NULL);
 
     assert(strcmp(result, "applEnd") == 0);
 
@@ -58,7 +58,7 @@ void test_single_replacement_in_middle(void) {
     const char* replacements[256] = {NULL};
     replacements['p'] = "P";
 
-    char* result = pretokenizer_encode(text, replacements);
+    char* result = pretokenizer_encode(text, replacements, NULL);
 
     assert(strcmp(result, "aPPle") == 0);
 
@@ -71,7 +71,7 @@ void test_multiple_different_replacements(void) {
     replacements['a'] = "ab";
     replacements['e'] = "ef";
 
-    char* result = pretokenizer_encode(text, replacements);
+    char* result = pretokenizer_encode(text, replacements, NULL);
 
     assert(strcmp(result, "abpplef") == 0);
 
@@ -83,7 +83,7 @@ void test_multiple_occurrences_of_same_char(void) {
     const char* replacements[256] = {NULL};
     replacements['a'] = "o";
 
-    char* result = pretokenizer_encode(text, replacements);
+    char* result = pretokenizer_encode(text, replacements, NULL);
 
     assert(strcmp(result, "bonono") == 0);
 
@@ -95,7 +95,7 @@ void test_replacement_with_empty_string(void) {
     const char* replacements[256] = {NULL};
     replacements['l'] = "";
 
-    char* result = pretokenizer_encode(text, replacements);
+    char* result = pretokenizer_encode(text, replacements, NULL);
 
     assert(strcmp(result, "heo") == 0);
 
@@ -107,7 +107,7 @@ void test_empty_input_string(void) {
     const char* replacements[256] = {NULL};
     replacements['a'] = "b";
 
-    char* result = pretokenizer_encode(text, replacements);
+    char* result = pretokenizer_encode(text, replacements, NULL);
 
     assert(strcmp(result, "") == 0);
 
@@ -121,7 +121,7 @@ void test_all_chars_are_replaced(void) {
     replacements['b'] = "22";
     replacements['c'] = "333";
 
-    char* result = pretokenizer_encode(text, replacements);
+    char* result = pretokenizer_encode(text, replacements, NULL);
 
     assert(strcmp(result, "122333") == 0);
 
@@ -133,9 +133,56 @@ void test_replacement_with_single_char(void) {
     const char* replacements[256] = {NULL};
     replacements['t'] = "T";
 
-    char* result = pretokenizer_encode(text, replacements);
+    char* result = pretokenizer_encode(text, replacements, NULL);
 
     assert(strcmp(result, "TesT") == 0);
+
+    free(result);
+}
+
+void test_with_prefix_and_replacements(void) {
+    const char* text = "apple";
+    const char* replacements[256] = {NULL};
+    replacements['a'] = "A";
+    replacements['e'] = "E";
+
+    char* result = pretokenizer_encode(text, replacements, "Juicy ");
+
+    assert(strcmp(result, "Juicy ApplE") == 0);
+
+    free(result);
+}
+
+void test_with_prefix_and_empty_string_replacement(void) {
+    const char* text = "-abc-";
+    const char* replacements[256] = {NULL};
+    replacements['-'] = "";
+
+    char* result = pretokenizer_encode(text, replacements, "Prefix:");
+
+    assert(strcmp(result, "Prefix:abc") == 0);
+
+    free(result);
+}
+
+void test_with_prefix_and_empty_input_string(void) {
+    const char* text = "";
+    const char* replacements[256] = {NULL};
+
+    char* result = pretokenizer_encode(text, replacements, "Start:");
+
+    assert(strcmp(result, "Start:") == 0);
+
+    free(result);
+}
+
+void test_with_empty_string_as_prefix(void) {
+    const char* text = "test";
+    const char* replacements[256] = {NULL};
+
+    char* result = pretokenizer_encode(text, replacements, "");
+
+    assert(strcmp(result, "test") == 0);
 
     free(result);
 }
@@ -154,6 +201,10 @@ int main(void) {
     RUN_TEST(test_empty_input_string);
     RUN_TEST(test_all_chars_are_replaced);
     RUN_TEST(test_replacement_with_single_char);
+    RUN_TEST(test_with_prefix_and_replacements);
+    RUN_TEST(test_with_prefix_and_empty_string_replacement);
+    RUN_TEST(test_with_prefix_and_empty_input_string);
+    RUN_TEST(test_with_empty_string_as_prefix);
 
     puts("\nAll tests passed successfully!");
 

--- a/tests/test_pretokenizer.c
+++ b/tests/test_pretokenizer.c
@@ -13,8 +13,8 @@
 
 void test_null_input_string(void) {
     const char* replacements[256] = {NULL};
-    char* result_encoded = pretokenizer_encode(NULL, replacements, NULL);
-    char* result_decoded = pretokenizer_decode(NULL, replacements, NULL);
+    char* result_encoded = pretokenizer_encode(NULL, replacements, NULL, false);
+    char* result_decoded = pretokenizer_decode(NULL, replacements, NULL, false);
 
     assert(result_encoded == NULL);
     assert(result_decoded == NULL);
@@ -24,9 +24,9 @@ void test_no_replacements_needed(void) {
     const char* text = "hello world";
     const char* replacements[256] = {NULL};
 
-    char* result_encoded = pretokenizer_encode(text, replacements, NULL);
+    char* result_encoded = pretokenizer_encode(text, replacements, NULL, false);
     char* result_decoded =
-        pretokenizer_decode(result_encoded, replacements, NULL);
+        pretokenizer_decode(result_encoded, replacements, NULL, false);
 
     assert(strcmp(result_encoded, "hello world") == 0);
     assert(strcmp(result_decoded, text) == 0);
@@ -40,9 +40,9 @@ void test_single_replacement_at_start(void) {
     const char* replacements[256] = {NULL};
     replacements['a'] = "Alpha";
 
-    char* result_encoded = pretokenizer_encode(text, replacements, NULL);
+    char* result_encoded = pretokenizer_encode(text, replacements, NULL, false);
     char* result_decoded =
-        pretokenizer_decode(result_encoded, replacements, NULL);
+        pretokenizer_decode(result_encoded, replacements, NULL, false);
 
     assert(strcmp(result_encoded, "Alphapple") == 0);
     assert(strcmp(result_decoded, text) == 0);
@@ -56,9 +56,9 @@ void test_single_replacement_at_end(void) {
     const char* replacements[256] = {NULL};
     replacements['e'] = "End";
 
-    char* result_encoded = pretokenizer_encode(text, replacements, NULL);
+    char* result_encoded = pretokenizer_encode(text, replacements, NULL, false);
     char* result_decoded =
-        pretokenizer_decode(result_encoded, replacements, NULL);
+        pretokenizer_decode(result_encoded, replacements, NULL, false);
 
     assert(strcmp(result_encoded, "applEnd") == 0);
     assert(strcmp(result_decoded, text) == 0);
@@ -72,9 +72,9 @@ void test_single_replacement_in_middle(void) {
     const char* replacements[256] = {NULL};
     replacements['p'] = "P";
 
-    char* result_encoded = pretokenizer_encode(text, replacements, NULL);
+    char* result_encoded = pretokenizer_encode(text, replacements, NULL, false);
     char* result_decoded =
-        pretokenizer_decode(result_encoded, replacements, NULL);
+        pretokenizer_decode(result_encoded, replacements, NULL, false);
 
     assert(strcmp(result_encoded, "aPPle") == 0);
     assert(strcmp(result_decoded, text) == 0);
@@ -89,9 +89,9 @@ void test_multiple_different_replacements(void) {
     replacements['a'] = "ab";
     replacements['e'] = "ef";
 
-    char* result_encoded = pretokenizer_encode(text, replacements, NULL);
+    char* result_encoded = pretokenizer_encode(text, replacements, NULL, false);
     char* result_decoded =
-        pretokenizer_decode(result_encoded, replacements, NULL);
+        pretokenizer_decode(result_encoded, replacements, NULL, false);
 
     assert(strcmp(result_encoded, "abpplef") == 0);
     assert(strcmp(result_decoded, text) == 0);
@@ -105,9 +105,9 @@ void test_multiple_occurrences_of_same_char(void) {
     const char* replacements[256] = {NULL};
     replacements['a'] = "o";
 
-    char* result_encoded = pretokenizer_encode(text, replacements, NULL);
+    char* result_encoded = pretokenizer_encode(text, replacements, NULL, false);
     char* result_decoded =
-        pretokenizer_decode(result_encoded, replacements, NULL);
+        pretokenizer_decode(result_encoded, replacements, NULL, false);
 
     assert(strcmp(result_encoded, "bonono") == 0);
     assert(strcmp(result_decoded, text) == 0);
@@ -123,7 +123,7 @@ void test_replacement_with_empty_string(void) {
     const char* replacements[256] = {NULL};
     replacements['l'] = "";
 
-    char* result = pretokenizer_encode(text, replacements, NULL);
+    char* result = pretokenizer_encode(text, replacements, NULL, false);
 
     assert(strcmp(result, "heo") == 0);
 
@@ -135,9 +135,9 @@ void test_empty_input_string(void) {
     const char* replacements[256] = {NULL};
     replacements['a'] = "b";
 
-    char* result_encoded = pretokenizer_encode(text, replacements, NULL);
+    char* result_encoded = pretokenizer_encode(text, replacements, NULL, false);
     char* result_decoded =
-        pretokenizer_decode(result_encoded, replacements, NULL);
+        pretokenizer_decode(result_encoded, replacements, NULL, false);
 
     assert(strcmp(result_encoded, "") == 0);
     assert(strcmp(result_decoded, text) == 0);
@@ -153,9 +153,9 @@ void test_all_chars_are_replaced(void) {
     replacements['b'] = "22";
     replacements['c'] = "333";
 
-    char* result_encoded = pretokenizer_encode(text, replacements, NULL);
+    char* result_encoded = pretokenizer_encode(text, replacements, NULL, false);
     char* result_decoded =
-        pretokenizer_decode(result_encoded, replacements, NULL);
+        pretokenizer_decode(result_encoded, replacements, NULL, false);
 
     assert(strcmp(result_encoded, "122333") == 0);
     assert(strcmp(result_decoded, text) == 0);
@@ -169,9 +169,9 @@ void test_replacement_with_single_char(void) {
     const char* replacements[256] = {NULL};
     replacements['t'] = "T";
 
-    char* result_encoded = pretokenizer_encode(text, replacements, NULL);
+    char* result_encoded = pretokenizer_encode(text, replacements, NULL, false);
     char* result_decoded =
-        pretokenizer_decode(result_encoded, replacements, NULL);
+        pretokenizer_decode(result_encoded, replacements, NULL, false);
 
     assert(strcmp(result_encoded, "TesT") == 0);
     assert(strcmp(result_decoded, text) == 0);
@@ -187,9 +187,9 @@ void test_with_prefix_and_replacements(void) {
     replacements['e'] = "E";
     const char* prefix = "Juicy ";
 
-    char* result_encoded = pretokenizer_encode(text, replacements, prefix);
+    char* result_encoded = pretokenizer_encode(text, replacements, prefix, false);
     char* result_decoded =
-        pretokenizer_decode(result_encoded, replacements, prefix);
+        pretokenizer_decode(result_encoded, replacements, prefix, false);
 
     assert(strcmp(result_encoded, "Juicy ApplE") == 0);
     assert(strcmp(result_decoded, text) == 0);
@@ -206,7 +206,7 @@ void test_with_prefix_and_empty_string_replacement(void) {
     replacements['-'] = "";
     const char* prefix = "Prefix:";
 
-    char* result = pretokenizer_encode(text, replacements, prefix);
+    char* result = pretokenizer_encode(text, replacements, prefix, false);
 
     assert(strcmp(result, "Prefix:abc") == 0);
 
@@ -218,9 +218,9 @@ void test_with_prefix_and_empty_input_string(void) {
     const char* replacements[256] = {NULL};
     const char* prefix = "Start:";
 
-    char* result_encoded = pretokenizer_encode(text, replacements, prefix);
+    char* result_encoded = pretokenizer_encode(text, replacements, prefix, false);
     char* result_decoded =
-        pretokenizer_decode(result_encoded, replacements, prefix);
+        pretokenizer_decode(result_encoded, replacements, prefix, false);
 
     assert(strcmp(result_encoded, "Start:") == 0);
     assert(strcmp(result_decoded, text) == 0);
@@ -234,11 +234,26 @@ void test_with_empty_string_as_prefix(void) {
     const char* replacements[256] = {NULL};
     const char* prefix = "";
 
-    char* result_encoded = pretokenizer_encode(text, replacements, prefix);
+    char* result_encoded = pretokenizer_encode(text, replacements, prefix, false);
     char* result_decoded =
-        pretokenizer_decode(result_encoded, replacements, prefix);
+        pretokenizer_decode(result_encoded, replacements, prefix, false);
 
     assert(strcmp(result_encoded, "test") == 0);
+    assert(strcmp(result_decoded, text) == 0);
+
+    free(result_encoded);
+    free(result_decoded);
+}
+
+void test_with_multibyte_char(void) {
+    const char* text = "midőn";
+    const char* replacements[256] = {NULL};
+    const char* prefix = NULL;
+    replacements[145] = "ĳ";
+
+    char* result_encoded = pretokenizer_encode(text, replacements, prefix, true);
+    char* result_decoded = pretokenizer_decode(result_encoded, replacements, prefix, true);
+
     assert(strcmp(result_decoded, text) == 0);
 
     free(result_encoded);
@@ -263,6 +278,7 @@ int main(void) {
     RUN_TEST(test_with_prefix_and_empty_string_replacement);
     RUN_TEST(test_with_prefix_and_empty_input_string);
     RUN_TEST(test_with_empty_string_as_prefix);
+    RUN_TEST(test_with_multibyte_char);
 
     puts("\nAll tests passed successfully!");
 

--- a/tests/test_string.c
+++ b/tests/test_string.c
@@ -1,0 +1,249 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "hutoken/string.h"
+
+#define RUN_TEST(test)                          \
+    do {                                        \
+        printf("Running test: %s...\n", #test); \
+        test();                                 \
+    } while (0)
+
+void test_init_small_string(void) {
+    struct String str;
+
+    assert(string_init(&str, "hello") == STRING_SUCCESS);
+    assert(str.is_large == false);
+    assert(string_len(&str) == 5);
+    assert(strcmp(string_c_str(&str), "hello") == 0);
+
+    string_release(&str);
+}
+
+void test_init_large_string(void) {
+    const char* large_str =
+        "This string is intentionally made very long to "
+        "exceed SSO buffer.";
+    size_t large_str_len = strlen(large_str);
+    assert(large_str_len > STRING_SSO_MAX_LEN);
+
+    struct String str;
+
+    assert(string_init(&str, large_str) == STRING_SUCCESS);
+    assert(str.is_large == true);
+    assert(string_len(&str) == large_str_len);
+    assert(strcmp(string_c_str(&str), large_str) == 0);
+
+    string_release(&str);
+}
+
+void test_init_empty_string(void) {
+    struct String str;
+
+    assert(string_init(&str, "") == STRING_SUCCESS);
+    assert(str.is_large == false);
+    assert(string_len(&str) == 0);
+    assert(strcmp(string_c_str(&str), "") == 0);
+
+    string_release(&str);
+}
+
+void test_init_null_string(void) {
+    struct String str;
+
+    assert(string_init(&str, NULL) == STRING_SUCCESS);
+    assert(str.is_large == false);
+    assert(string_len(&str) == 0);
+    assert(strcmp(string_c_str(&str), "") == 0);
+
+    string_release(&str);
+}
+
+void test_init_sso_max_len_is_small(void) {
+    struct String str;
+    char sso_max[STRING_SSO_MAX_LEN + 1];
+    memset(sso_max, 'a', STRING_SSO_MAX_LEN);
+    sso_max[STRING_SSO_MAX_LEN] = '\0';
+
+    assert(string_init(&str, sso_max) == STRING_SUCCESS);
+    assert(str.is_large == false);
+    assert(string_len(&str) == STRING_SSO_MAX_LEN);
+
+    string_release(&str);
+}
+
+void test_init_sso_max_len_plus_one_is_large(void) {
+    struct String str;
+    char large_str[STRING_SSO_MAX_LEN + 2];
+    memset(large_str, 'a', STRING_SSO_MAX_LEN + 1);
+    large_str[STRING_SSO_MAX_LEN + 1] = '\0';
+
+    assert(string_init(&str, large_str) == STRING_SUCCESS);
+    assert(str.is_large == true);
+    assert(string_len(&str) == STRING_SSO_MAX_LEN + 1);
+
+    string_release(&str);
+}
+
+void test_with_capacity_small(void) {
+    struct String str;
+
+    assert(string_with_capacity(&str, 10) == STRING_SUCCESS);
+    assert(str.is_large == false);
+    assert(string_len(&str) == 0);
+
+    string_release(&str);
+}
+
+void test_with_capacity_sso_exact_is_small(void) {
+    struct String str;
+
+    assert(string_with_capacity(&str, STRING_SSO_MAX_LEN) == STRING_SUCCESS);
+    assert(str.is_large == false);
+    assert(string_len(&str) == 0);
+
+    string_release(&str);
+}
+
+void test_with_capacity_large(void) {
+    struct String str;
+
+    assert(string_with_capacity(&str, 100) == STRING_SUCCESS);
+    assert(str.is_large == true);
+    assert(string_len(&str) == 0);
+    assert(str.data.large.capacity == 100);
+
+    string_release(&str);
+}
+
+void test_append_to_small_remains_small(void) {
+    struct String str;
+    string_init(&str, "hu");
+
+    assert(string_append(&str, "token") == STRING_SUCCESS);
+    assert(str.is_large == false);
+    assert(string_len(&str) == 7);
+    assert(strcmp(string_c_str(&str), "hutoken") == 0);
+
+    string_release(&str);
+}
+
+void test_append_to_small_becomes_large(void) {
+    struct String str;
+    char almost_full[STRING_SSO_MAX_LEN];
+    memset(almost_full, 'a', STRING_SSO_MAX_LEN - 1);
+    almost_full[STRING_SSO_MAX_LEN - 1] = '\0';
+
+    string_init(&str, almost_full);
+    assert(str.is_large == false);
+
+    assert(string_append(&str, "123") == STRING_SUCCESS);
+    assert(str.is_large == true);
+    assert(string_len(&str) == STRING_SSO_MAX_LEN - 1 + 3);
+    assert(strncmp(string_c_str(&str), almost_full, STRING_SSO_MAX_LEN - 1) ==
+           0);
+    assert(strcmp(string_c_str(&str) + STRING_SSO_MAX_LEN - 1, "123") == 0);
+
+    string_release(&str);
+}
+
+void test_append_to_large_remains_large(void) {
+    struct String str;
+    string_with_capacity(&str, 100);
+    string_append(&str, "hello ");
+
+    assert(string_append(&str, "world!") == STRING_SUCCESS);
+    assert(str.is_large == true);
+    assert(string_len(&str) == 12);
+    assert(strcmp(string_c_str(&str), "hello world!") == 0);
+
+    string_release(&str);
+}
+
+void test_append_to_empty(void) {
+    struct String str;
+    string_init(&str, "");
+
+    assert(string_append(&str, "non-empty") == STRING_SUCCESS);
+    assert(string_len(&str) == 9);
+    assert(strcmp(string_c_str(&str), "non-empty") == 0);
+
+    string_release(&str);
+}
+
+void test_append_empty_string_is_noop(void) {
+    struct String str;
+    string_init(&str, "hutoken");
+
+    assert(string_append(&str, "") == STRING_SUCCESS);
+    assert(string_len(&str) == 7);
+    assert(strcmp(string_c_str(&str), "hutoken") == 0);
+
+    string_release(&str);
+}
+
+void test_init_handles_null_struct_ptr(void) {
+    assert(string_init(NULL, "abc") == STRING_INVALID_ARGUMENT);
+}
+
+void test_with_capacity_handles_null_struct_ptr(void) {
+    assert(string_with_capacity(NULL, 10) == STRING_INVALID_ARGUMENT);
+}
+
+void test_append_handles_null_struct_ptr(void) {
+    assert(string_append(NULL, "abc") == STRING_INVALID_ARGUMENT);
+}
+
+void test_append_handles_null_to_append_ptr(void) {
+    struct String str;
+    string_init(&str, "test");
+
+    assert(string_append(&str, NULL) == STRING_INVALID_ARGUMENT);
+
+    string_release(&str);
+}
+
+void test_len_handles_null_struct_ptr(void) {
+    assert(string_len(NULL) == 0);
+}
+
+void test_c_str_handles_null_struct_ptr(void) {
+    assert(strcmp(string_c_str(NULL), "") == 0);
+}
+
+void test_release_handles_null_struct_ptr(void) {
+    string_release(NULL);  // would cause segfault if doesn't work
+}
+
+int main(void) {
+    puts("Starting string tests.\n");
+
+    RUN_TEST(test_init_small_string);
+    RUN_TEST(test_init_large_string);
+    RUN_TEST(test_init_empty_string);
+    RUN_TEST(test_init_null_string);
+    RUN_TEST(test_init_sso_max_len_is_small);
+    RUN_TEST(test_init_sso_max_len_plus_one_is_large);
+    RUN_TEST(test_with_capacity_small);
+    RUN_TEST(test_with_capacity_sso_exact_is_small);
+    RUN_TEST(test_with_capacity_large);
+    RUN_TEST(test_append_to_small_remains_small);
+    RUN_TEST(test_append_to_small_becomes_large);
+    RUN_TEST(test_append_to_large_remains_large);
+    RUN_TEST(test_append_to_empty);
+    RUN_TEST(test_append_empty_string_is_noop);
+    RUN_TEST(test_init_handles_null_struct_ptr);
+    RUN_TEST(test_with_capacity_handles_null_struct_ptr);
+    RUN_TEST(test_append_handles_null_struct_ptr);
+    RUN_TEST(test_append_handles_null_to_append_ptr);
+    RUN_TEST(test_len_handles_null_struct_ptr);
+    RUN_TEST(test_c_str_handles_null_struct_ptr);
+    RUN_TEST(test_release_handles_null_struct_ptr);
+
+    puts("\nAll tests passed successfully!");
+
+    return EXIT_SUCCESS;
+}

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -94,12 +94,11 @@ def test_decode_basic_with_tiktoken():
 
 @pytest.mark.benchmark(disable_gc=True)
 def test_encode_speed():
-
     number = 10_000
     execution_time = timeit.timeit(
-        f'hutoken.encode("{sentence1}")',
-        setup="import hutoken; hutoken.initialize('./vocabs/gpt2-vocab.txt')",
-        number=number
+        lambda: hutoken.encode(sentence1),
+        setup="import hutoken; hutoken.initialize('./vocabs/gpt2-vocab.txt', './vocabs/gpt2-vocab_special_chars.txt')",
+        number=number,
     )
     print(f"Average execution time for {number} calls: {execution_time / number} seconds")
 
@@ -107,11 +106,10 @@ def test_encode_speed():
 
 
 def test_decode_speed():
-
     number = 10_000
     execution_time = timeit.timeit(
-        f"hutoken.decode(hutoken.encode('{sentence1}'))",
-        setup="import hutoken; hutoken.initialize('./vocabs/gpt2-vocab.txt')",
+        lambda: hutoken.decode(hutoken.encode(sentence1)),
+        setup="import hutoken; hutoken.initialize('./vocabs/gpt2-vocab.txt', './vocabs/gpt2-vocab_special_chars.txt')",
         number=number
     )
 
@@ -128,7 +126,7 @@ def test_initialize_invalid_format():
     with open('./vocabs/invalid-vocab.txt', 'w') as f:
         f.write("invalid_line_format\n")
     with pytest.raises(ValueError, match="Invalid format in vocab file."):
-        hutoken.initialize('./vocabs/invalid-vocab.txt')
+        hutoken.initialize('./vocabs/invalid-vocab.txt', './vocabs/invalid-vocab_special_chars.txt')
 
 
 def test_decode_invalid_tokens():

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -91,6 +91,16 @@ def test_decode_basic_with_tiktoken():
     assert hutoken.decode(hutoken.encode(paragraph1)) == paragraph1
     assert hutoken.decode(hutoken.encode(paragraph2)) == paragraph2
 
+def test_with_qwen():
+
+    hutoken.initialize("Qwen/Qwen2.5-Coder-0.5B-Instruct")
+
+    assert hutoken.decode(hutoken.encode(sentence1)) == sentence1
+    assert hutoken.decode(hutoken.encode(sentence2)) == sentence2
+    assert hutoken.decode(hutoken.encode(paragraph1)) == paragraph1
+    assert hutoken.decode(hutoken.encode(paragraph2)) == paragraph2
+
+
 
 @pytest.mark.benchmark(disable_gc=True)
 def test_encode_speed():
@@ -179,6 +189,7 @@ def test_decode_with_hugginface_using_hutoken_encdoe():
     ht_decoded = hutoken.decode(ht_tokens)
 
     assert ht_decoded == hf_decoded, f"Decoded text differs: {ht_decoded} vs {hf_decoded}"
+
 
 def test_morphological_analyzer():
     handle = hutoken.initialize_foma()

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -97,7 +97,7 @@ def test_encode_speed():
     number = 10_000
     execution_time = timeit.timeit(
         lambda: hutoken.encode(sentence1),
-        setup="import hutoken; hutoken.initialize('./vocabs/gpt2-vocab.txt', './vocabs/gpt2-vocab_special_chars.txt')",
+        setup="import hutoken; hutoken.initialize('./vocabs/gpt2-vocab.txt', './vocabs/gpt2-vocab_special_chars.txt', is_byte_encoder=True)",
         number=number,
     )
     print(f"Average execution time for {number} calls: {execution_time / number} seconds")
@@ -109,7 +109,7 @@ def test_decode_speed():
     number = 10_000
     execution_time = timeit.timeit(
         lambda: hutoken.decode(hutoken.encode(sentence1)),
-        setup="import hutoken; hutoken.initialize('./vocabs/gpt2-vocab.txt', './vocabs/gpt2-vocab_special_chars.txt')",
+        setup="import hutoken; hutoken.initialize('./vocabs/gpt2-vocab.txt', './vocabs/gpt2-vocab_special_chars.txt', is_byte_encoder=True)",
         number=number
     )
 

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -127,7 +127,7 @@ def test_initialize_success():
 def test_initialize_invalid_format():
     with open('./vocabs/invalid-vocab.txt', 'w') as f:
         f.write("invalid_line_format\n")
-    with pytest.raises(ValueError, match="Vocab file is empty or contains no valid entries."):
+    with pytest.raises(ValueError, match="Invalid format in vocab file."):
         hutoken.initialize('./vocabs/invalid-vocab.txt')
 
 


### PR DESCRIPTION
This pull request implements several fixes for previous errors related to HuggingFace's `transformers` library compatibility.

In particular, it introduces the following:

- While loading a vocab file, if a line is longer than 1024, it used to crash with an unexpected error. Now, via a dynamic string implementation, this is handled correctly. This creates a very small performance overhead (when allocating the new dynamic string for the line), however, this can be overlooked because this fixes a crucial issue in `initialize` which made the whole library crash.
- A pretokenization phase has been added, which swaps special characters to specific marker values used by each tokenizer. This step is implemented and tested in the `pretokenizer` module, and is called as the first step in `encode`, and as the last step in `decode` doing the reverse operation. (This whole step could be optimized with a hashmap lookup instead.)
- The `pretokenizer` module also handles other operations performed by the pretokenizer in standard tokenizers, which are as follows:

    - Appending and removing a prefix space, depending on whether the original tokenizer does that as well.
    - Multi-byte character separation, again, depending on whether the original tokenizer does that as well. If it does so, our library correctly identifies that and separates multi-byte UTF-8 characters (e.g., `í`) into single-byte characters and uses that representation in the BPE step. This separation is then reversed in the decoding phase, also handled in the same module.

Some remarks on the implementation details:

- This also adds more complexity to using the library with local vocab files, since now the special character mapping would also need to be passed to the library. This is automatically handled when passing a model name to the `initialize` function.
- The prefix character, and whether to separate multi-byte characters also need to be passed to the function when using local vocabulary files. This is, again, handled automatically when passing a model name to the function.
- As mentioned before, an implementation of the `pretokenizer` module's decode function could be made faster if instead of a search through the array, a hashmap lookup is performed. However, since this required a thorough rewrite of the hashmap module to make it generic over both the keys and the values, this detail has been delayed. Benchmarks would have to be performed to check whether it is actually faster.

    > I recommend that an issue is opened for this.

- This PR makes every current `pytest` pass, with an additional Qwen test as well.