### PR TITLE
PCRE2 integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ to the results.
     > your OS.
     > For example
 
+-   `pcre2` (PCRE - Perl Compatible Regular Expressions).
+
+    > The PCRE library is a set of functions that implement regular expression pattern matching using the same syntax and semantics as Perl 5. This library is required to use a more robust regex system (e.g.: use python style regex) instead of the standard C style POSIX regex for tokenization.
+    > Ubuntu/Debian: sudo apt-get install libpcre2-dev
+    > CentOS/RHEL/Fedora: sudo yum install pcre2-devel OR sudo dnf install pcre2-devel
+    > macOS: brew install pcre2
+
 # Installation
 
 ## PyPI

--- a/README.md
+++ b/README.md
@@ -60,10 +60,23 @@ to the results.
 -   `pcre2` (PCRE - Perl Compatible Regular Expressions).
 
     > The PCRE library is a set of functions that implement regular expression pattern matching using the same syntax and semantics as Perl 5. This library is required to use a more robust regex system (e.g.: use python style regex) instead of the standard C style POSIX regex for tokenization.
-    > Ubuntu/Debian: sudo apt-get install libpcre2-dev
-    > CentOS/RHEL/Fedora: sudo yum install pcre2-devel OR sudo dnf install pcre2-devel
-    > macOS: brew install pcre2
 
+    ### Installation of pcre2 on different systems:
+
+    Ubuntu/Debian:
+    ```bash
+    sudo apt-get install libpcre2-dev
+    ```
+
+    CentOS/RHEL/Fedora:
+    ```bash
+    sudo yum install pcre2-devel OR sudo dnf install pcre2-devel
+    ```
+    macOS: 
+    ```bash
+    brew install pcre2
+    ```
+    
 # Installation
 
 ## PyPI

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ sources = [
 
 include_dirs = ["include"]
 extra_compile_args = ["-O3", "-march=native", "-funroll-loops", "-Iinclude"]
-extra_link_args = ["-flto"]
+extra_link_args = ["-flto","-lpcre2-8"]
 
 if is_foma_installed():
     extra_compile_args.append("-DUSE_FOMA")

--- a/src/core.c
+++ b/src/core.c
@@ -106,7 +106,7 @@ void encode(char* text,
     regex = pcre2_compile(
         (PCRE2_SPTR)pattern,    /* the pattern */
         PCRE2_ZERO_TERMINATED,  /* indicates pattern is zero-terminated */
-        PCRE2_UTF,                      /* using UTF-8 */
+        PCRE2_UTF,              /* using UTF-8 */
         &errorcode,             /* for error code */
         &erroroffset,           /* for error offset */
         NULL);    

--- a/src/lib.c
+++ b/src/lib.c
@@ -24,9 +24,7 @@
 static bool initialized_encode = false;
 static bool initialized_decode = false;
 static char* pattern =
-    "[ ]?[A-Za-záéíóúőűüöÁÉÍÓÚŐÜŰÖ]+|[ ]?[0-9]+|[ "
-    "]?[^[:space:][:alpha:][:digit:]]+|[ ]+";
-
+    """'s|'t|'re|'ve|'m|'ll|'d| ?[\p{L}]+| ?[\p{N}]+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+""";
 struct HashMap* vocab_encode;
 char** vocab_decode;
 int vocab_size_decode;


### PR DESCRIPTION
Created new branch pcre2-integration to replace standard POSIX regex with PCRE2. With this modification hutoken can now support a much bigger variety of regular expressions (e.g.: Python regex).

- In lib.c the previous regex is replaced with the Python regex from tiktoken.
- In setup.py added -lpcre2-8 to link against the PCRE2 libraries.
- In core.c the encode function is re-written to use PCRE2, with UTF-8 support.
- In bpe.c the create_words function is re-written to use PCRE2, with UTF-8 support.
- Added instructions to README.md for the pcre2 libs install.
